### PR TITLE
Change table layout to auto

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -82,6 +82,7 @@
   white-space: pre !important;
 }
 .syntaxhighlighter table {
+  table-layout: auto;
   width: 100% !important;
 }
 .syntaxhighlighter table caption {


### PR DESCRIPTION
Some themes (like Twenty Fifteen) force table layouts to `fixed`, thus breaking the layout of the syntax highlighter.
