### PR TITLE
Update font-family in shCore.css for OS X users

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -44,7 +44,7 @@
   vertical-align: baseline !important;
   width: auto !important;
   box-sizing: content-box !important;
-  font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace !important;
+  font-family: Monaco, "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace !important;
   font-weight: normal !important;
   font-style: normal !important;
   font-size: 1em !important;


### PR DESCRIPTION
As "Consolas" and "bitstream Vera Sans Mono" not exists on OS X by default, the font of code will fall to "Courier New", but the default and beautiful mono font on OS X is Monaco, so I add this on the front of font-family
