### PR TITLE
Remove limitation on the R language

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -202,7 +202,7 @@ class SyntaxHighlighter {
 			'powershell'    => 'powershell',
 			'py'            => 'python',
 			'python'        => 'python',
-			'r'             => 'r', // Not used as a shortcode
+			'r'             => 'r',
 			'splus'         => 'r',
 			'rails'         => 'ruby',
 			'rb'            => 'ruby',
@@ -227,7 +227,6 @@ class SyntaxHighlighter {
 
 		// Remove some shortcodes we don't want while still supporting them as language values
 		unset( $this->shortcodes[array_search( 'latex', $this->shortcodes )] ); // Remove "latex" shortcode (it'll collide)
-		unset( $this->shortcodes[array_search( 'r', $this->shortcodes )] ); // Remove "r" shortcode (too short)
 
 		$this->shortcodes = (array) apply_filters( 'syntaxhighlighter_shortcodes', $this->shortcodes );
 


### PR DESCRIPTION
We run a blog that uses your syntaxhighlighter and we have a lot of R content. It would be really nice if we could use the [r] shortcode instead of the longer syntax. I looked in the [API docs](https://codex.wordpress.org/Shortcode_API#Limitations) and couldn't see a limitation for 1 character shortcodes, that doesn't mean one doesn't exist.

Thanks!
