### PR TITLE
Add 'async' and 'await' keywords to JScriptBrush

### DIFF
--- a/syntaxhighlighter3/scripts/shBrushJScript.js
+++ b/syntaxhighlighter3/scripts/shBrushJScript.js
@@ -26,7 +26,8 @@
 				'for function if implements import in instanceof ' +
 				'interface let new null package private protected ' +
 				'static return super switch ' +
-				'this throw true try typeof var while with yield';
+				'this throw true try typeof var while with yield ' +
+	                        'async await';
 
 		var r = SyntaxHighlighter.regexLib;
 		


### PR DESCRIPTION
Add highlighting for syntax introduced in proposal https://tc39.github.io/ecmascript-asyncawait/ (which has been implemented in Chrome, Edge and Firefox) so far --- we want to use this to promote the feature!
