### PR TITLE
Add transforms to/from core code block

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -101,6 +101,22 @@ registerBlockType( 'syntaxhighlighter/code', {
 					},
 				},
 			},
+			{
+				type: 'block',
+				blocks: [ 'core/code' ],
+				transform: ( { content } ) => {
+					return createBlock( 'syntaxhighlighter/code', { content } );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/code' ],
+				transform: ( { content } ) => {
+					return createBlock( 'core/code', { content } );
+				},
+			},
 		],
 	},
 


### PR DESCRIPTION
This adds transforms so that SyntaxHighlighter code blocks can be
directly converted from and to the Gutenberg `core/code` blocks.

When pasting a markdown post into Gutenberg, code blocks in the post are
automatically converted to `core/code` blocks, so I have to manually
change them into SyntaxHighlighter blocks instead. Without this patch,
that means creating a new block, copy/pasting the content of the old
block to the new one, and then deleting the old block. For a long post
this takes quite a lot of time. With this change it will be a two-click
operation per block.

![screen shot 2019-01-25 at 6 01 57 pm](https://user-images.githubusercontent.com/2036909/51777580-ad552880-20cb-11e9-8492-7b837725690a.png)
