### PR TITLE
Decode all html special characters escaped by WP

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -513,7 +513,7 @@ class SyntaxHighlighter {
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
 		// Undo escaping done by WordPress
-		$code = str_replace( '&lt;', '<', $code );
+		$code = htmlspecialchars_decode( $code );
 
 		return $this->shortcode_callback( $attributes, $code, 'code' );
 	}


### PR DESCRIPTION
Instead of just handling <, handle all html special characters.

This solves the problem where code containing `&`, for example, is rendered to the page as `&amp;` instead of the original `&` as expected.

Fixes https://wordpress.org/support/topic/syntaxhighlighter-plugin-displays-as-g-t/

From: https://github.com/Viper007Bond/syntaxhighlighter/pull/109