### PR TITLE
Remove setting line-height, causing conflicts

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -7,7 +7,7 @@
  *
  * @version
  * 3.0.83 (July 02 2010)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2010 Alex Gorbatchev.
  *
@@ -32,7 +32,6 @@
   float: none !important;
   height: auto !important;
   left: auto !important;
-  line-height: 1.1em !important;
   margin: 0 !important;
   outline: 0 !important;
   overflow: visible !important;


### PR DESCRIPTION
This fix removes setting the line-height by the syntax highlighter this causes issues for seeing underscores in single line blocks.

This depends on the font size, zoom your browser font using ctrl+ to see. Two example sites you can see the issue are:
https://wordpress.org/support/article/configuring-automatic-background-updates/
https://jetpack.com/support/development-mode/

![syntax-highlighter](https://user-images.githubusercontent.com/45363/67899261-27b14e00-fb1f-11e9-9d02-0abfd70e7b89.jpg)

![Screenshot from 2019-10-30 13-41-01](https://user-images.githubusercontent.com/45363/67899274-2da72f00-fb1f-11e9-8e5d-cf83c2cdd435.png)
