### PR TITLE
Added Arduino Brush

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -123,6 +123,7 @@ class SyntaxHighlighter {
 		// Register brush scripts
 		wp_register_script( 'syntaxhighlighter-core',             plugins_url( $this->shfolder . '/scripts/shCore.js',            __FILE__ ), array(),                         $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-as3',        plugins_url( $this->shfolder . '/scripts/shBrushAS3.js',        __FILE__ ), array('syntaxhighlighter-core'), $this->agshver );
+		wp_register_script( 'syntaxhighlighter-brush-arduino',    plugins_url( $this->shfolder . '/scripts/shBrushArduino.js',    __FILE__ ), array('syntaxhighlighter-core'), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-bash',       plugins_url( $this->shfolder . '/scripts/shBrushBash.js',       __FILE__ ), array('syntaxhighlighter-core'), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-coldfusion', plugins_url( $this->shfolder . '/scripts/shBrushColdFusion.js', __FILE__ ), array('syntaxhighlighter-core'), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-cpp',        plugins_url( $this->shfolder . '/scripts/shBrushCpp.js',        __FILE__ ), array('syntaxhighlighter-core'), $this->agshver );
@@ -172,6 +173,7 @@ class SyntaxHighlighter {
 		$this->brushes = (array) apply_filters( 'syntaxhighlighter_brushes', array(
 			'as3'           => 'as3',
 			'actionscript3' => 'as3',
+			'arduino'       => 'arduino',
 			'bash'          => 'bash',
 			'shell'         => 'bash',
 			'coldfusion'    => 'coldfusion',
@@ -232,6 +234,7 @@ class SyntaxHighlighter {
 
 		$this->brush_names = (array) apply_filters( 'syntaxhighlighter_brush_names', array(
 			'as3'        => __( 'ActionScript',              'syntaxhighlighter' ),
+			'arduino'    => __( 'Arduino',                   'syntaxhighlighter' ),
 			'bash'       => __( 'BASH / Shell',              'syntaxhighlighter' ),
 			'coldfusion' => __( 'ColdFusion',                'syntaxhighlighter' ),
 			'clojure'    => __( 'Clojure',                   'syntaxhighlighter' ),

--- a/syntaxhighlighter3/scripts/shBrushArduino.js
+++ b/syntaxhighlighter3/scripts/shBrushArduino.js
@@ -54,7 +54,6 @@
 		,{ regex: /\b0x[0-9A-Fa-f]+[uU]?[lL]?\b/gm,					css: 'constants'} 	// numeric constants (hexidecimal)
 		,{ regex: /\bB[01]{1,8}\b/gm,								css: 'constants'} 	// numeric constants (binary)
 		,{ regex: /\+|\-|\*|\/|\%|!|\||\&amp;|=|\?|\^|~/gm, 			css: 'plain bold' }		// operators
-       //,{ regex: /\b(?:\w+?(?=\(.*?\)\W))/gm,							css: 'plain italic'}		// Other functions/macros (i.e. user-defined)
 		];
 	};
 

--- a/syntaxhighlighter3/scripts/shBrushArduino.js
+++ b/syntaxhighlighter3/scripts/shBrushArduino.js
@@ -1,0 +1,68 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (Wed, 16 Apr 2014 03:56:09 GMT)
+ *
+ * @copyright
+ * Copyright (C) 2004-2013 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ *
+ * Original brush carlynorama/wp-syntaxhighlighter-arduino updated April 2020 by https://siytek.com
+ */
+;(function()
+{
+	// CommonJS
+	SyntaxHighlighter = SyntaxHighlighter || (typeof require !== 'undefined'? require('shCore').SyntaxHighlighter : null);
+
+	function Brush()
+	{
+
+	var datatypes =	'boolean char byte int long float double void unsigned volatile word string static const';
+
+	var keywords =	'setup loop if else for switch case default while do break continue return';
+
+	var functions =	'pinMode digitalWrite digitalRead analogRead analogWrite shiftOut pulseIn ' +
+			'millis micros delay delayMicroseconds min max abs constrain ' +
+			'map pow sq sqrt sin cos tan randomSeed random ' +
+			'sizeof lowByte highByte bitRead bitWrite bitSet bitClear bit tone noTone' +
+			'attachInterrupt detachInterrupt interrupts noInterrupts ' +
+			'Serial\\.begin Serial\\.available Serial\\.read Serial\\.flush ' +
+			'Serial\\.print Serial\\.println Serial\\.write ';
+
+	var constants = 'HIGH LOW INPUT OUTPUT true false CHANGE RISING FALLING';
+
+
+	this.regexList = [
+		{ regex: SyntaxHighlighter.regexLib.singleLineCComments,	css: 'comments' }			// one line comments
+		,{ regex: SyntaxHighlighter.regexLib.multiLineCComments,		css: 'comments' }			// multiline comments
+		,{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,		css: 'string' }			// strings
+		,{ regex: SyntaxHighlighter.regexLib.singleQuotedString,		css: 'string' }			// strings
+		,{ regex: /^ *#(.)+?\b/gm,									css: 'preprocessor' }		// preprocessor directives
+		,{ regex: new RegExp(this.getKeywords(datatypes), 'gm'),		css: 'color1 bold' } 		// datatypes
+		,{ regex: new RegExp(this.getKeywords(functions), 'gm'),		css: 'functions' } 	// functions
+		,{ regex: new RegExp(this.getKeywords(keywords), 'gm'),		css: 'keyword bold' } 		// control flow
+		,{ regex: new RegExp(this.getKeywords(constants), 'gm'),		css: 'constants bold' } 	// predefined constants
+		,{ regex: /\b(\d*\.\d+([Ee]-?\d{1,3})?)|(\d+[Ee]-?\d{1,3})\b/gm,	css: 'constants'} // numeric constants (floating point)
+		,{ regex: /\b\d+[uU]?[lL]?\b/gm,								css: 'constants'} 	// numeric constants (decimal)
+		,{ regex: /\b0x[0-9A-Fa-f]+[uU]?[lL]?\b/gm,					css: 'constants'} 	// numeric constants (hexidecimal)
+		,{ regex: /\bB[01]{1,8}\b/gm,								css: 'constants'} 	// numeric constants (binary)
+		,{ regex: /\+|\-|\*|\/|\%|!|\||\&amp;|=|\?|\^|~/gm, 			css: 'plain bold' }		// operators
+       //,{ regex: /\b(?:\w+?(?=\(.*?\)\W))/gm,							css: 'plain italic'}		// Other functions/macros (i.e. user-defined)
+		];
+	};
+
+	Brush.prototype	= new SyntaxHighlighter.Highlighter();
+	Brush.aliases	= ['arduino', 'arduinolite'];
+
+	SyntaxHighlighter.brushes.Arduino = Brush;
+
+	// CommonJS
+	typeof(exports) != 'undefined' ? exports.Brush = Brush : null;
+})();


### PR DESCRIPTION
Updated the [Arduino Brush by carlynorama](https://github.com/carlynorama/wp-syntaxhighlighter-arduino) and added the brush to the scripts folder. Added the brush to `syntaxhighlighter.php`. 

Example @ https://siytek.com/communication-between-two-esp8266/

![image](https://user-images.githubusercontent.com/13923284/78892708-c5f7f700-7a61-11ea-94a2-e80d9e6232aa.png)
