### PR TITLE
Fix adding classname when using SyntaxHighlighter block

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -500,6 +500,7 @@ class SyntaxHighlighter {
 	 */
 	public function render_block( $attributes, $content ) {
 		$remaps = array(
+			'className'         => 'classname',
 			'lineNumbers'       => 'gutter',
 			'firstLineNumber'   => 'firstline',
 			'highlightLines'    => 'highlight',

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1244,7 +1244,7 @@ class SyntaxHighlighter {
 
 			// Sanitize the "classname" parameter
 			if ( 'class-name' == $key )
-				$value = trim( preg_replace( '/[^a-zA-Z0-9 _-]/i', '', $value ) );
+				$value = "'" . trim( preg_replace( '/[^a-zA-Z0-9 _-]/i', '', $value ) ) . "'";
 
 			// Special sanitization for "pad-line-numbers"
 			if ( 'pad-line-numbers' == $key ) {


### PR DESCRIPTION
Fixes #123 and fixes #130

#### Changes proposed in this Pull Request:

* Fix adding classname when using Syntax Highlighter block

#### Testing instructions:

* Create a new Syntax Highlighter block in a post or page.
* In the sidebar, `Advanced` → `Additional CSS class(es)` add a class.
* Open the page on the frontend and check if the class was added.