### PR TITLE
Fix tags issue while alternating visual and text mode in the classic editor

### DIFF
--- a/syntaxhighlighter.js
+++ b/syntaxhighlighter.js
@@ -15,9 +15,9 @@
 				}
 			);
 		}
-	}).on( 'beforeWpautop.syntaxhighlighter', function( event, obj ) {
+	}).on( 'afterWpautop.syntaxhighlighter', function( event, obj ) {
 		if ( obj.data && obj.data.indexOf( '[' ) !== -1 ) {
-			obj.data = obj.data.replace( regex, '<pre>$1</pre>' );
+			obj.data = obj.unfiltered.replace( regex, '<pre>$1</pre>' );
 		}
 	}).ready( function() {
 		$( '.wp-editor-wrap.html-active' ).each( function( i, element ) {

--- a/syntaxhighlighter.js
+++ b/syntaxhighlighter.js
@@ -59,7 +59,14 @@
 		}
 	}).on( 'afterWpautop.syntaxhighlighter', function( event, obj ) {
 		if ( obj.data && obj.data.indexOf( '[' ) !== -1 ) {
-			obj.data = preserveTags( obj.unfiltered.replace( regex, '<pre>$1</pre>' ) );
+			var i = 0;
+			var unfilteredCodes = obj.unfiltered.match( regex );
+
+			obj.data = obj.data.replace( regex, function() {
+				// Replace by the unfiltered code piece.
+				var unfilteredCode = unfilteredCodes[ i++ ];
+				return `<pre>${ preserveTags( unfilteredCode ) }</pre>`;
+			} );
 		}
 	}).ready( function() {
 		$( '.wp-editor-wrap.html-active' ).each( function( i, element ) {


### PR DESCRIPTION
Fixes #128 and fixes #127

#### Changes proposed in this Pull Request:

* Fix some issues while alternating between visual and text mode in the classic editor. The main issue is that it was creating some new lines.
* The other issue mentioned is that the angle brackets were appearing as `&lt;`. I could not reproduce it, but I believe these changes will fix it as well.

The main idea of this solution was to restore the unfiltered codes after the `afterWpautop`.

* I also identified that `<p>` and `<br>` tags were being removed in the core. So I replaced it temporarily to `<wp-p>` and `<wp-br>` tags. It'll appear only in the visual mode if the user changes from the text mode.

#### Testing instructions:

* Install and active the classic editor.
* Create a new post with the SyntaxHighlighter shortcode `[code language="php"]` or `[html]`. Please, test mixing and not mixing other texts in the post.
* Also test using `<p>` and `<br />` tags inner your code.
* Make sure that the shortcodes are keeping the indentation and break lines correctly, as well the angle brackets. And the rest of the content continues being treated as before.
* If possible, also test using the WP 4.2.3 (where the errors happened too) to confirm everything is working well. I tested here and it seems to be working fine as well.