### PR TITLE
Remove <code> wrapper

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -5,8 +5,6 @@ import { escape } from './utils';
 
 export default function save( { attributes } ) {
 	return (
-		<pre>
-			<code>{ escape( attributes.content ) }</code>
-		</pre>
+		<pre>{ escape( attributes.content ) }</pre>
 	);
 }

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -527,7 +527,7 @@ class SyntaxHighlighter {
 			}
 		}
 
-		$code = preg_replace( '#<pre [^>]+><code>([^<]+)?</code></pre>#', '$1', $content );
+		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
 		// Undo escaping done by WordPress
 		$code = str_replace( '&lt;', '<', $code );


### PR DESCRIPTION
Fixes #162

### Changes proposed

- Remove the extra `<code>` tag inside the `<pre>` wrapper as it introduces backward compatiblility issues

### Testing instructions

- Create a post with a Syntaxhighlighter block on version `3.5.5` with any content
- Update to this branch
- Open the post frontend without saving the post again
- Make sure the block is rendered correctly (without the extra `<pre class..` before and after)