### PR TITLE
Use tab size from plugin settings in block editor

### DIFF
--- a/src/code-block/edit.js
+++ b/src/code-block/edit.js
@@ -8,8 +8,12 @@ export default function editSyntaxHighlighterBlock( { attributes, setAttributes,
 		content,
 	} = attributes;
 
+	const { settings: { tabSize } } = window.syntaxHighlighterData;
+
 	const editView = <div className={ className + ' wp-block-code' }>
 		<PlainText
+			className="wp-block-syntaxhighlighter__textarea"
+			style={ { tabSize, '-moz-tab-size': '' + tabSize } }
 			value={ content }
 			onChange={ ( nextContent ) => setAttributes( { content: nextContent } ) }
 			placeholder={ __( 'Tip: you can choose a code language from the block settings.', 'syntaxhighlighter' ) }

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -373,6 +373,7 @@ class SyntaxHighlighter {
 				'supported' => ( '3' == $this->settings['shversion'] ),
 				'default' => (bool) $this->settings['quickcode'],
 			),
+			'tabSize' => (int) $this->settings['tabsize'],
 		);
 
 		wp_add_inline_script(


### PR DESCRIPTION
Depends on #171

### Changes proposed in this Pull Request

* Respect tab size settings in the editor 

### Testing instructions

* Set the `Tab size` option to a value of *not 8* in Plugins > Syntaxhighlighter Evolved > Settings
* Edit a post, add code block, insert code with tabs
* Observe tab is not 8 spaces wide but respects the setting

