### PR TITLE
Fix escaping for shortcodes and URLs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,26 +17,5 @@ import { escapeEditableHTML } from '@wordpress/escape-html';
 export function escape( content ) {
 	return flow(
 		escapeEditableHTML,
-		escapeProtocolInIsolatedUrls
 	)( content || '' );
-}
-/**
- * Converts the first two forward slashes of any isolated URL into their HTML
- * counterparts (i.e. // => &#47;&#47;). For instance, https://youtube.com/watch?x
- * becomes https:&#47;&#47;youtube.com/watch?x.
- *
- * An isolated URL is a URL that sits in its own line, surrounded only by spacing
- * characters.
- *
- * See https://github.com/WordPress/wordpress-develop/blob/5.1.1/src/wp-includes/class-wp-embed.php#L403
- *
- * @param {string}  content The content of a code block.
- * @return {string} The given content with its ampersands converted into
- *                  their HTML entity counterpart (i.e. & => &amp;)
- */
-function escapeProtocolInIsolatedUrls( content ) {
-	return content.replace(
-		/^(\s*https?:)\/\/([^\s<>"]+\s*)$/m,
-		'$1&#47;&#47;$2'
-	);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,28 +17,9 @@ import { escapeEditableHTML } from '@wordpress/escape-html';
 export function escape( content ) {
 	return flow(
 		escapeEditableHTML,
-		escapeOpeningSquareBrackets,
 		escapeProtocolInIsolatedUrls
 	)( content || '' );
 }
-
-/**
- * Returns the given content with all opening shortcode characters converted
- * into their HTML entity counterpart (i.e. [ => &#91;). For instance, a
- * shortcode like [embed] becomes &#91;embed]
- *
- * This function replicates the escaping of HTML tags, where a tag like
- * <strong> becomes &lt;strong>.
- *
- * @param {string}  content The content of a code block.
- * @return {string} The given content with its opening shortcode characters
- *                  converted into their HTML entity counterpart
- *                  (i.e. [ => &#91;)
- */
-function escapeOpeningSquareBrackets( content ) {
-	return content.replace( /\[/g, '&#91;' );
-}
-
 /**
  * Converts the first two forward slashes of any isolated URL into their HTML
  * counterparts (i.e. // => &#47;&#47;). For instance, https://youtube.com/watch?x

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,5 +17,27 @@ import { escapeEditableHTML } from '@wordpress/escape-html';
 export function escape( content ) {
 	return flow(
 		escapeEditableHTML,
+		escapeProtocolInIsolatedUrls
 	)( content || '' );
+}
+
+/**
+ * Converts the first two forward slashes of any isolated URL into their HTML
+ * counterparts (i.e. // => &#47;&#47;). For instance, https://youtube.com/watch?x
+ * becomes https:&#47;&#47;youtube.com/watch?x.
+ *
+ * An isolated URL is a URL that sits in its own line, surrounded only by spacing
+ * characters.
+ *
+ * See https://github.com/WordPress/wordpress-develop/blob/5.1.1/src/wp-includes/class-wp-embed.php#L403
+ *
+ * @param {string}  content The content of a code block.
+ * @return {string} The given content with its ampersands converted into
+ *                  their HTML entity counterpart (i.e. & => &amp;)
+ */
+function escapeProtocolInIsolatedUrls( content ) {
+	return content.replace(
+		/^(\s*https?:)\/\/([^\s<>"]+\s*)$/m,
+		'$1&#47;&#47;$2'
+	);
 }

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -529,6 +529,9 @@ class SyntaxHighlighter {
 
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
+		// Escape shortcodes
+		$code = preg_replace( '/\[(\w+)]/', '[[$1]]', $code );
+
 		// Undo escaping done by WordPress
 		$code = str_replace( '&lt;', '<', $code );
 		$code = str_replace( '&amp;', '&', $code );

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -535,6 +535,7 @@ class SyntaxHighlighter {
 		// Undo escaping done by WordPress
 		$code = str_replace( '&lt;', '<', $code );
 		$code = str_replace( '&amp;', '&', $code );
+		$code = preg_replace(  '/^(\s*https?:)&#47;&#47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
 
 		return $this->shortcode_callback( $attributes, $code, 'code' );
 	}

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -530,7 +530,7 @@ class SyntaxHighlighter {
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
 		// Escape shortcodes
-		$code = preg_replace( '/\[(\w+)]/', '[[$1]]', $code );
+		$code = preg_replace('/' . get_shortcode_regex() . '/', '[$0]', $code );
 
 		// Undo escaping done by WordPress
 		$code = str_replace( '&lt;', '<', $code );


### PR DESCRIPTION
Fixes #176 

### Changes proposed in this Pull Request

* Escape shortcodes in the PHP render callback with `[[double_brackets]]` syntax.
* Remove escaping `//` in URLs. Haven't found a case where this would be need, and Syntaxhighlighter handles URLs, with the option to make them clickable

### Testing instructions

* See https://codex.wordpress.org/Shortcode_API#Formal_Syntax for shortcode syntax examples. Make sure to use a valid shortcode, like `gallery`.
* Add various shortcodes to a code block
* Ensure the shortcodes are not replaced on the frontend, but displayed as in the editor
* Ensure code block content remains the same when opening an existing post (no extra escaped/unescaped content, see #152 )

