### PR TITLE
Add block alignment support

### DIFF
--- a/src/code-block/index.js
+++ b/src/code-block/index.js
@@ -54,6 +54,7 @@ export default {
 	},
 	supports: {
 		html: false,
+		align: true,
 	},
 	transforms,
 	edit,

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -515,6 +515,9 @@ class SyntaxHighlighter {
 			'quickCode'         => 'quickcode',
 		);
 		$classNames = ! empty( $attributes['className'] ) ? [ esc_attr( $attributes['className'] ) ] : [];
+		if( ! empty( $attributes['align'] ) ) {
+			$classNames[] = 'align' . esc_attr( $attributes['align'] );
+		}
 
 		foreach ( $remaps as $from => $to ) {
 			if ( isset( $attributes[ $from ] ) ) {

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -507,7 +507,6 @@ class SyntaxHighlighter {
 	 */
 	public function render_block( $attributes, $content ) {
 		$remaps = array(
-			'className'         => 'classname',
 			'lineNumbers'       => 'gutter',
 			'firstLineNumber'   => 'firstline',
 			'highlightLines'    => 'highlight',
@@ -515,6 +514,7 @@ class SyntaxHighlighter {
 			'makeURLsClickable' => 'autolinks',
 			'quickCode'         => 'quickcode',
 		);
+		$classNames = ! empty( $attributes['className'] ) ? [ esc_attr( $attributes['className'] ) ] : [];
 
 		foreach ( $remaps as $from => $to ) {
 			if ( isset( $attributes[ $from ] ) ) {
@@ -538,7 +538,9 @@ class SyntaxHighlighter {
 		$code = str_replace( '&amp;', '&', $code );
 		$code = preg_replace(  '/^(\s*https?:)&#47;&#47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
 
-		return $this->shortcode_callback( $attributes, $code, 'code' );
+		$code = $this->shortcode_callback( $attributes, $code, 'code' );
+
+		return '<div class="wp-block-syntaxhighlighter-code ' . esc_attr( join(' ', $classNames ) ) . '">' . $code . '</div>';
 	}
 
 	// Add the custom TinyMCE plugin which wraps plugin shortcodes in <pre> in TinyMCE
@@ -1330,7 +1332,7 @@ class SyntaxHighlighter {
 
 		$params = apply_filters( 'syntaxhighlighter_cssclasses', $params ); // Use this to add additional CSS classes / SH parameters
 
-		return apply_filters( 'syntaxhighlighter_htmlresult', '<pre class="' . esc_attr( implode( ' ', $params ) ) . '"' . $title . '>' . $code . '</pre>' );;
+		return apply_filters( 'syntaxhighlighter_htmlresult', '<pre class="' . esc_attr( implode( ' ', $params ) ) . '"' . $title . '>' . $code . '</pre>' );
 	}
 
 


### PR DESCRIPTION

Code lines are usually longer than text content, and do not work well wrapped, so supporting block alignment options like wide and full width can make life easier.

### Changes proposed in this Pull Request

* Move block classes to top-level wrapper element, with `wp-block-syntaxhighlighter-code` class.
  * This bring the behavior of *Additional classes* closer to how other blocks work
  * And is needed for some block customization options like alignment and styles  
  * Fixes #146
* Add block alignment support

### Testing instructions

* Use a theme with Wide/Full block alignment support, like Twenty Twenty
* Add a Syntaxhighlighter code block, set some block alignment
* Check that it works on the frontend
