### PR TITLE
Add ```language shortcut

### DIFF
--- a/src/code-block/transforms.js
+++ b/src/code-block/transforms.js
@@ -4,8 +4,13 @@ export default {
 	from: [
 		{
 			type: 'enter',
-			regExp: /^```$/,
-			transform: () => createBlock( 'syntaxhighlighter/code' ),
+			regExp: /^```\w*$/,
+			transform: ( { content = '' } ) => {
+				const [ , language ] = content.match( /^```(\w+)/ ) || [ null, null ];
+
+				const attributes = language ? { language } : undefined;
+				return createBlock( 'syntaxhighlighter/code', attributes );
+			},
 		},
 		{
 			type: 'raw',


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Improve the current ` ``` ` shortcut to also allow specifying a language

### Testing instructions

* Open a post in the block editor
* Type ` ```php ` and press enter
* A Syntaxhighlighter Code block should be added with the language set to PHP
* Type ` ``` ` and press enter
* The code block should be added with `Plain text` language

