### PR TITLE
Update plugin tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === SyntaxHighlighter Evolved ===
 Contributors: Viper007Bond, automattic, donncha
 Donate link: https://alex.blog/2019/03/13/in-memory-of-alex-donation-link-update/
-Tags: code, sourcecode, block, php, xhtml, html, css, WordPress.com
+Tags: code, source, sourcecode, php, syntax highlighting, syntax, highlight, highlighting, highlighter, WordPress.com
 Requires at least: 4.2.3
 Tested up to: 5.4
 Stable tag: 3.5.5


### PR DESCRIPTION

The plugin is a bit hard to find on Wordpress.org searches, with some common tags like `syntax highlight` missing

### Changes proposed in this Pull Request

* Update plugin tags in readme

### Testing instructions

* N/A

