### PR TITLE
Ensure HTML special characters don't get double-encoded

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -530,8 +530,7 @@ class SyntaxHighlighter {
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
 		// Undo escaping done by WordPress
-		$code = str_replace( '&lt;', '<', $code );
-		$code = str_replace( '&amp;', '&', $code );
+		$code = htmlspecialchars_decode( $code );
 
 		return $this->shortcode_callback( $attributes, $code, 'code' );
 	}


### PR DESCRIPTION
I believe this will address the issues described in #108 and #159. At first I thought I would just add

`$code = str_replace( '&gt;', '>', $code );`

...as a third line under "Undo escaping...", but then I figured it would potentially catch more edge cases to just decode all HTML entities at this point in the code. Entities get re-encoded later in the `shortcode_callback` method, so this helps further prevent double-encoding.