### PR TITLE
Fix escaping for non-admin authored posts

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -533,9 +533,6 @@ class SyntaxHighlighter {
 
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
-		// Escape shortcodes
-		$code = preg_replace('/' . get_shortcode_regex() . '/', '[$0]', $code );
-
 		// Undo escaping done by WordPress
 		$code = htmlspecialchars_decode( $code );
 		$code = preg_replace(  '/^(\s*https?:)&#0?47;&#0?47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
@@ -1329,6 +1326,9 @@ class SyntaxHighlighter {
 		}
 
 		$code = ( false === strpos( $code, '<' ) && false === strpos( $code, '>' ) && 2 == $this->get_code_format($post) ) ? strip_tags( $code ) : htmlspecialchars( $code );
+
+		// Escape shortcodes
+		$code = preg_replace( '/\[/', '&#91;', $code );
 
 		$params[] = 'notranslate'; // For Google, see http://otto42.com/9k
 

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -537,9 +537,8 @@ class SyntaxHighlighter {
 		$code = preg_replace('/' . get_shortcode_regex() . '/', '[$0]', $code );
 
 		// Undo escaping done by WordPress
-		$code = str_replace( '&lt;', '<', $code );
-		$code = str_replace( '&amp;', '&', $code );
-		$code = preg_replace(  '/^(\s*https?:)&#47;&#47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
+		$code = htmlspecialchars_decode( $code );
+		$code = preg_replace(  '/^(\s*https?:)&#0?47;&#0?47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
 
 		$code = $this->shortcode_callback( $attributes, $code, 'code' );
 


### PR DESCRIPTION
Fixes #159
Includes #182

### Changes proposed in this Pull Request

* Change shortcode escaping to html encoding, run after htmlspecialchars
* Decode all HTML special characters to prevent double encoding

### Testing instructions

* Create a post with a non-administrator user
* Add a Syntaxhighlighter block, with various code examples, and valid shortcodes, like this:
```
<?php echo 'Hello World'; ?> 

[gallery id="123" size="medium"] xxx [/gallery]
 
https://www.youtube.com/watch?v=21X5lGlDOfg
```
* Publish & view on frontend. Ensure characters are displayed correctly.

