### PR TITLE
Fix MatLab brush key in brush map

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -206,6 +206,7 @@ class SyntaxHighlighter {
 			'latex'         => 'latex', // Not used as a shortcode
 			'tex'           => 'latex',
 			'matlab'        => 'matlabkey',
+			'matlabkey'     => 'matlabkey',
 			'objc'          => 'objc',
 			'obj-c'         => 'objc',
 			'perl'          => 'perl',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/38788

### Changes proposed in this Pull Request

* This array has some ambiguity in its uses throughout the plugin. Sometimes the language check is `isset( $this->brushes[$lang] )` and sometimes it is `in_array( $lang, $this->brushes, true )`. In addition, I think the _block_ actually uses the brush names and not language names for its language selector. 
* All other languages have a key entry for every value entry. I did the same with MatLab to fix the issue.

### Testing instructions

* See issue.