### PR TITLE
removed 	type='text/javascript' to pass HTML5

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -937,7 +937,7 @@ class SyntaxHighlighter {
 		wp_print_scripts( $scripts );
 
 		// Stylesheets can't be in the footer, so inject them via Javascript
-		echo "<script type='text/javascript'>\n";
+		echo "<script>\n";
 		echo "	(function(){\n";
 		echo "		var corecss = document.createElement('link');\n";
 		echo "		var themecss = document.createElement('link');\n";


### PR DESCRIPTION
type='text/javascript' will trigger warnings for HTML5 validation, type it's deprecated and should be removed.

Fixes #

Change in syntaxhighlighter.php line 940  from <script type='text/javascript'> to <script>.

There are two places where syntaxhighlighter.php will include the script tag with the deprecated attribute, but the first one is for the admin interface so is less important but the one on 940, will echo the script to the frontend, where is more important for the DOM to pass validation.  

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

type='text/javascript'

