### PR TITLE
Fix line ending style

### DIFF
--- a/syntaxhighlighter2/scripts/shBrushAS3.js
+++ b/syntaxhighlighter2/scripts/shBrushAS3.js
@@ -7,41 +7,41 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.AS3 = function()
 {
 	// Created by Peter Atoria @ http://iAtoria.com
-	
+
 	var inits 	 =  'class interface function package';
-	
-	var keywords =	'-Infinity ...rest Array as AS3 Boolean break case catch const continue Date decodeURI ' + 
-					'decodeURIComponent default delete do dynamic each else encodeURI encodeURIComponent escape ' + 
-					'extends false final finally flash_proxy for get if implements import in include Infinity ' + 
-					'instanceof int internal is isFinite isNaN isXMLName label namespace NaN native new null ' + 
-					'Null Number Object object_proxy override parseFloat parseInt private protected public ' + 
-					'return set static String super switch this throw true try typeof uint undefined unescape ' + 
+
+	var keywords =	'-Infinity ...rest Array as AS3 Boolean break case catch const continue Date decodeURI ' +
+					'decodeURIComponent default delete do dynamic each else encodeURI encodeURIComponent escape ' +
+					'extends false final finally flash_proxy for get if implements import in include Infinity ' +
+					'instanceof int internal is isFinite isNaN isXMLName label namespace NaN native new null ' +
+					'Null Number Object object_proxy override parseFloat parseInt private protected public ' +
+					'return set static String super switch this throw true try typeof uint undefined unescape ' +
 					'use void while with'
 					;
-	
+
 	this.regexList = [
 		{ regex: SyntaxHighlighter.regexLib.singleLineCComments,	css: 'comments' },		// one line comments
 		{ regex: SyntaxHighlighter.regexLib.multiLineCComments,		css: 'comments' },		// multiline comments
@@ -53,7 +53,7 @@ SyntaxHighlighter.brushes.AS3 = function()
 		{ regex: new RegExp('var', 'gm'),							css: 'variable' },		// variable
 		{ regex: new RegExp('trace', 'gm'),							css: 'color1' }			// trace
 		];
-	
+
 	this.forHtmlScript(SyntaxHighlighter.regexLib.scriptScriptTags);
 };
 

--- a/syntaxhighlighter2/scripts/shBrushBash.js
+++ b/syntaxhighlighter2/scripts/shBrushBash.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -45,7 +45,7 @@ SyntaxHighlighter.brushes.Bash = function()
 					'uname unexpand uniq units unset unshar useradd usermod users uuencode uudecode v vdir ' +
 					'vi watch wc whereis which who whoami Wget xargs yes'
 					;
-	
+
 	this.findMatches = function(regexList, code)
 	{
 		code = code.replace(/&gt;/g, '>').replace(/&lt;/g, '<');

--- a/syntaxhighlighter2/scripts/shBrushCSharp.js
+++ b/syntaxhighlighter2/scripts/shBrushCSharp.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -43,7 +43,7 @@ SyntaxHighlighter.brushes.CSharp = function()
 			? 'color1'
 			: 'comments'
 			;
-			
+
 		return [new SyntaxHighlighter.Match(match[0], match.index, css)];
 	}
 
@@ -58,7 +58,7 @@ SyntaxHighlighter.brushes.CSharp = function()
 		{ regex: /\bpartial(?=\s+(?:class|interface|struct)\b)/g,	css: 'keyword' },			// contextual keyword: 'partial'
 		{ regex: /\byield(?=\s+(?:return|break)\b)/g,				css: 'keyword' }			// contextual keyword: 'yield'
 		];
-		
+
 	this.forHtmlScript(SyntaxHighlighter.regexLib.aspScriptTags);
 };
 

--- a/syntaxhighlighter2/scripts/shBrushColdFusion.js
+++ b/syntaxhighlighter2/scripts/shBrushColdFusion.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -31,58 +31,58 @@ SyntaxHighlighter.brushes.ColdFusion = function()
 {
 	// Contributed by Jen
 	// http://www.jensbits.com/2009/05/14/coldfusion-brush-for-syntaxhighlighter-plus
-	
-	var funcs	=	'Abs ACos AddSOAPRequestHeader AddSOAPResponseHeader AjaxLink AjaxOnLoad ArrayAppend ArrayAvg ArrayClear ArrayDeleteAt ' + 
-					'ArrayInsertAt ArrayIsDefined ArrayIsEmpty ArrayLen ArrayMax ArrayMin ArraySet ArraySort ArraySum ArraySwap ArrayToList ' + 
-					'Asc ASin Atn BinaryDecode BinaryEncode BitAnd BitMaskClear BitMaskRead BitMaskSet BitNot BitOr BitSHLN BitSHRN BitXor ' + 
-					'Ceiling CharsetDecode CharsetEncode Chr CJustify Compare CompareNoCase Cos CreateDate CreateDateTime CreateObject ' + 
-					'CreateODBCDate CreateODBCDateTime CreateODBCTime CreateTime CreateTimeSpan CreateUUID DateAdd DateCompare DateConvert ' + 
-					'DateDiff DateFormat DatePart Day DayOfWeek DayOfWeekAsString DayOfYear DaysInMonth DaysInYear DE DecimalFormat DecrementValue ' + 
-					'Decrypt DecryptBinary DeleteClientVariable DeserializeJSON DirectoryExists DollarFormat DotNetToCFType Duplicate Encrypt ' + 
-					'EncryptBinary Evaluate Exp ExpandPath FileClose FileCopy FileDelete FileExists FileIsEOF FileMove FileOpen FileRead ' + 
-					'FileReadBinary FileReadLine FileSetAccessMode FileSetAttribute FileSetLastModified FileWrite Find FindNoCase FindOneOf ' + 
-					'FirstDayOfMonth Fix FormatBaseN GenerateSecretKey GetAuthUser GetBaseTagData GetBaseTagList GetBaseTemplatePath ' + 
-					'GetClientVariablesList GetComponentMetaData GetContextRoot GetCurrentTemplatePath GetDirectoryFromPath GetEncoding ' + 
-					'GetException GetFileFromPath GetFileInfo GetFunctionList GetGatewayHelper GetHttpRequestData GetHttpTimeString ' + 
-					'GetK2ServerDocCount GetK2ServerDocCountLimit GetLocale GetLocaleDisplayName GetLocalHostIP GetMetaData GetMetricData ' + 
-					'GetPageContext GetPrinterInfo GetProfileSections GetProfileString GetReadableImageFormats GetSOAPRequest GetSOAPRequestHeader ' + 
-					'GetSOAPResponse GetSOAPResponseHeader GetTempDirectory GetTempFile GetTemplatePath GetTickCount GetTimeZoneInfo GetToken ' + 
-					'GetUserRoles GetWriteableImageFormats Hash Hour HTMLCodeFormat HTMLEditFormat IIf ImageAddBorder ImageBlur ImageClearRect ' + 
-					'ImageCopy ImageCrop ImageDrawArc ImageDrawBeveledRect ImageDrawCubicCurve ImageDrawLine ImageDrawLines ImageDrawOval ' + 
-					'ImageDrawPoint ImageDrawQuadraticCurve ImageDrawRect ImageDrawRoundRect ImageDrawText ImageFlip ImageGetBlob ImageGetBufferedImage ' + 
-					'ImageGetEXIFTag ImageGetHeight ImageGetIPTCTag ImageGetWidth ImageGrayscale ImageInfo ImageNegative ImageNew ImageOverlay ImagePaste ' + 
-					'ImageRead ImageReadBase64 ImageResize ImageRotate ImageRotateDrawingAxis ImageScaleToFit ImageSetAntialiasing ImageSetBackgroundColor ' + 
-					'ImageSetDrawingColor ImageSetDrawingStroke ImageSetDrawingTransparency ImageSharpen ImageShear ImageShearDrawingAxis ImageTranslate ' + 
-					'ImageTranslateDrawingAxis ImageWrite ImageWriteBase64 ImageXORDrawingMode IncrementValue InputBaseN Insert Int IsArray IsBinary ' + 
-					'IsBoolean IsCustomFunction IsDate IsDDX IsDebugMode IsDefined IsImage IsImageFile IsInstanceOf IsJSON IsLeapYear IsLocalHost ' + 
-					'IsNumeric IsNumericDate IsObject IsPDFFile IsPDFObject IsQuery IsSimpleValue IsSOAPRequest IsStruct IsUserInAnyRole IsUserInRole ' + 
-					'IsUserLoggedIn IsValid IsWDDX IsXML IsXmlAttribute IsXmlDoc IsXmlElem IsXmlNode IsXmlRoot JavaCast JSStringFormat LCase Left Len ' + 
-					'ListAppend ListChangeDelims ListContains ListContainsNoCase ListDeleteAt ListFind ListFindNoCase ListFirst ListGetAt ListInsertAt ' + 
-					'ListLast ListLen ListPrepend ListQualify ListRest ListSetAt ListSort ListToArray ListValueCount ListValueCountNoCase LJustify Log ' + 
-					'Log10 LSCurrencyFormat LSDateFormat LSEuroCurrencyFormat LSIsCurrency LSIsDate LSIsNumeric LSNumberFormat LSParseCurrency LSParseDateTime ' + 
-					'LSParseEuroCurrency LSParseNumber LSTimeFormat LTrim Max Mid Min Minute Month MonthAsString Now NumberFormat ParagraphFormat ParseDateTime ' + 
-					'Pi PrecisionEvaluate PreserveSingleQuotes Quarter QueryAddColumn QueryAddRow QueryConvertForGrid QueryNew QuerySetCell QuotedValueList Rand ' + 
-					'Randomize RandRange REFind REFindNoCase ReleaseComObject REMatch REMatchNoCase RemoveChars RepeatString Replace ReplaceList ReplaceNoCase ' + 
-					'REReplace REReplaceNoCase Reverse Right RJustify Round RTrim Second SendGatewayMessage SerializeJSON SetEncoding SetLocale SetProfileString ' + 
-					'SetVariable Sgn Sin Sleep SpanExcluding SpanIncluding Sqr StripCR StructAppend StructClear StructCopy StructCount StructDelete StructFind ' + 
-					'StructFindKey StructFindValue StructGet StructInsert StructIsEmpty StructKeyArray StructKeyExists StructKeyList StructKeyList StructNew ' + 
-					'StructSort StructUpdate Tan TimeFormat ToBase64 ToBinary ToScript ToString Trim UCase URLDecode URLEncodedFormat URLSessionFormat Val ' + 
-					'ValueList VerifyClient Week Wrap Wrap WriteOutput XmlChildPos XmlElemNew XmlFormat XmlGetNodeType XmlNew XmlParse XmlSearch XmlTransform ' + 
+
+	var funcs	=	'Abs ACos AddSOAPRequestHeader AddSOAPResponseHeader AjaxLink AjaxOnLoad ArrayAppend ArrayAvg ArrayClear ArrayDeleteAt ' +
+					'ArrayInsertAt ArrayIsDefined ArrayIsEmpty ArrayLen ArrayMax ArrayMin ArraySet ArraySort ArraySum ArraySwap ArrayToList ' +
+					'Asc ASin Atn BinaryDecode BinaryEncode BitAnd BitMaskClear BitMaskRead BitMaskSet BitNot BitOr BitSHLN BitSHRN BitXor ' +
+					'Ceiling CharsetDecode CharsetEncode Chr CJustify Compare CompareNoCase Cos CreateDate CreateDateTime CreateObject ' +
+					'CreateODBCDate CreateODBCDateTime CreateODBCTime CreateTime CreateTimeSpan CreateUUID DateAdd DateCompare DateConvert ' +
+					'DateDiff DateFormat DatePart Day DayOfWeek DayOfWeekAsString DayOfYear DaysInMonth DaysInYear DE DecimalFormat DecrementValue ' +
+					'Decrypt DecryptBinary DeleteClientVariable DeserializeJSON DirectoryExists DollarFormat DotNetToCFType Duplicate Encrypt ' +
+					'EncryptBinary Evaluate Exp ExpandPath FileClose FileCopy FileDelete FileExists FileIsEOF FileMove FileOpen FileRead ' +
+					'FileReadBinary FileReadLine FileSetAccessMode FileSetAttribute FileSetLastModified FileWrite Find FindNoCase FindOneOf ' +
+					'FirstDayOfMonth Fix FormatBaseN GenerateSecretKey GetAuthUser GetBaseTagData GetBaseTagList GetBaseTemplatePath ' +
+					'GetClientVariablesList GetComponentMetaData GetContextRoot GetCurrentTemplatePath GetDirectoryFromPath GetEncoding ' +
+					'GetException GetFileFromPath GetFileInfo GetFunctionList GetGatewayHelper GetHttpRequestData GetHttpTimeString ' +
+					'GetK2ServerDocCount GetK2ServerDocCountLimit GetLocale GetLocaleDisplayName GetLocalHostIP GetMetaData GetMetricData ' +
+					'GetPageContext GetPrinterInfo GetProfileSections GetProfileString GetReadableImageFormats GetSOAPRequest GetSOAPRequestHeader ' +
+					'GetSOAPResponse GetSOAPResponseHeader GetTempDirectory GetTempFile GetTemplatePath GetTickCount GetTimeZoneInfo GetToken ' +
+					'GetUserRoles GetWriteableImageFormats Hash Hour HTMLCodeFormat HTMLEditFormat IIf ImageAddBorder ImageBlur ImageClearRect ' +
+					'ImageCopy ImageCrop ImageDrawArc ImageDrawBeveledRect ImageDrawCubicCurve ImageDrawLine ImageDrawLines ImageDrawOval ' +
+					'ImageDrawPoint ImageDrawQuadraticCurve ImageDrawRect ImageDrawRoundRect ImageDrawText ImageFlip ImageGetBlob ImageGetBufferedImage ' +
+					'ImageGetEXIFTag ImageGetHeight ImageGetIPTCTag ImageGetWidth ImageGrayscale ImageInfo ImageNegative ImageNew ImageOverlay ImagePaste ' +
+					'ImageRead ImageReadBase64 ImageResize ImageRotate ImageRotateDrawingAxis ImageScaleToFit ImageSetAntialiasing ImageSetBackgroundColor ' +
+					'ImageSetDrawingColor ImageSetDrawingStroke ImageSetDrawingTransparency ImageSharpen ImageShear ImageShearDrawingAxis ImageTranslate ' +
+					'ImageTranslateDrawingAxis ImageWrite ImageWriteBase64 ImageXORDrawingMode IncrementValue InputBaseN Insert Int IsArray IsBinary ' +
+					'IsBoolean IsCustomFunction IsDate IsDDX IsDebugMode IsDefined IsImage IsImageFile IsInstanceOf IsJSON IsLeapYear IsLocalHost ' +
+					'IsNumeric IsNumericDate IsObject IsPDFFile IsPDFObject IsQuery IsSimpleValue IsSOAPRequest IsStruct IsUserInAnyRole IsUserInRole ' +
+					'IsUserLoggedIn IsValid IsWDDX IsXML IsXmlAttribute IsXmlDoc IsXmlElem IsXmlNode IsXmlRoot JavaCast JSStringFormat LCase Left Len ' +
+					'ListAppend ListChangeDelims ListContains ListContainsNoCase ListDeleteAt ListFind ListFindNoCase ListFirst ListGetAt ListInsertAt ' +
+					'ListLast ListLen ListPrepend ListQualify ListRest ListSetAt ListSort ListToArray ListValueCount ListValueCountNoCase LJustify Log ' +
+					'Log10 LSCurrencyFormat LSDateFormat LSEuroCurrencyFormat LSIsCurrency LSIsDate LSIsNumeric LSNumberFormat LSParseCurrency LSParseDateTime ' +
+					'LSParseEuroCurrency LSParseNumber LSTimeFormat LTrim Max Mid Min Minute Month MonthAsString Now NumberFormat ParagraphFormat ParseDateTime ' +
+					'Pi PrecisionEvaluate PreserveSingleQuotes Quarter QueryAddColumn QueryAddRow QueryConvertForGrid QueryNew QuerySetCell QuotedValueList Rand ' +
+					'Randomize RandRange REFind REFindNoCase ReleaseComObject REMatch REMatchNoCase RemoveChars RepeatString Replace ReplaceList ReplaceNoCase ' +
+					'REReplace REReplaceNoCase Reverse Right RJustify Round RTrim Second SendGatewayMessage SerializeJSON SetEncoding SetLocale SetProfileString ' +
+					'SetVariable Sgn Sin Sleep SpanExcluding SpanIncluding Sqr StripCR StructAppend StructClear StructCopy StructCount StructDelete StructFind ' +
+					'StructFindKey StructFindValue StructGet StructInsert StructIsEmpty StructKeyArray StructKeyExists StructKeyList StructKeyList StructNew ' +
+					'StructSort StructUpdate Tan TimeFormat ToBase64 ToBinary ToScript ToString Trim UCase URLDecode URLEncodedFormat URLSessionFormat Val ' +
+					'ValueList VerifyClient Week Wrap Wrap WriteOutput XmlChildPos XmlElemNew XmlFormat XmlGetNodeType XmlNew XmlParse XmlSearch XmlTransform ' +
 					'XmlValidate Year YesNoFormat';
 
-	var keywords =	'cfabort cfajaximport cfajaxproxy cfapplet cfapplication cfargument cfassociate cfbreak cfcache cfcalendar ' + 
-					'cfcase cfcatch cfchart cfchartdata cfchartseries cfcol cfcollection cfcomponent cfcontent cfcookie cfdbinfo ' + 
-					'cfdefaultcase cfdirectory cfdiv cfdocument cfdocumentitem cfdocumentsection cfdump cfelse cfelseif cferror ' + 
-					'cfexchangecalendar cfexchangeconnection cfexchangecontact cfexchangefilter cfexchangemail cfexchangetask ' + 
-					'cfexecute cfexit cffeed cffile cfflush cfform cfformgroup cfformitem cfftp cffunction cfgrid cfgridcolumn ' + 
-					'cfgridrow cfgridupdate cfheader cfhtmlhead cfhttp cfhttpparam cfif cfimage cfimport cfinclude cfindex ' + 
-					'cfinput cfinsert cfinterface cfinvoke cfinvokeargument cflayout cflayoutarea cfldap cflocation cflock cflog ' + 
-					'cflogin cfloginuser cflogout cfloop cfmail cfmailparam cfmailpart cfmenu cfmenuitem cfmodule cfNTauthenticate ' + 
-					'cfobject cfobjectcache cfoutput cfparam cfpdf cfpdfform cfpdfformparam cfpdfparam cfpdfsubform cfpod cfpop ' + 
-					'cfpresentation cfpresentationslide cfpresenter cfprint cfprocessingdirective cfprocparam cfprocresult ' + 
-					'cfproperty cfquery cfqueryparam cfregistry cfreport cfreportparam cfrethrow cfreturn cfsavecontent cfschedule ' + 
-					'cfscript cfsearch cfselect cfset cfsetting cfsilent cfslider cfsprydataset cfstoredproc cfswitch cftable ' + 
-					'cftextarea cfthread cfthrow cftimer cftooltip cftrace cftransaction cftree cftreeitem cftry cfupdate cfwddx ' + 
+	var keywords =	'cfabort cfajaximport cfajaxproxy cfapplet cfapplication cfargument cfassociate cfbreak cfcache cfcalendar ' +
+					'cfcase cfcatch cfchart cfchartdata cfchartseries cfcol cfcollection cfcomponent cfcontent cfcookie cfdbinfo ' +
+					'cfdefaultcase cfdirectory cfdiv cfdocument cfdocumentitem cfdocumentsection cfdump cfelse cfelseif cferror ' +
+					'cfexchangecalendar cfexchangeconnection cfexchangecontact cfexchangefilter cfexchangemail cfexchangetask ' +
+					'cfexecute cfexit cffeed cffile cfflush cfform cfformgroup cfformitem cfftp cffunction cfgrid cfgridcolumn ' +
+					'cfgridrow cfgridupdate cfheader cfhtmlhead cfhttp cfhttpparam cfif cfimage cfimport cfinclude cfindex ' +
+					'cfinput cfinsert cfinterface cfinvoke cfinvokeargument cflayout cflayoutarea cfldap cflocation cflock cflog ' +
+					'cflogin cfloginuser cflogout cfloop cfmail cfmailparam cfmailpart cfmenu cfmenuitem cfmodule cfNTauthenticate ' +
+					'cfobject cfobjectcache cfoutput cfparam cfpdf cfpdfform cfpdfformparam cfpdfparam cfpdfsubform cfpod cfpop ' +
+					'cfpresentation cfpresentationslide cfpresenter cfprint cfprocessingdirective cfprocparam cfprocresult ' +
+					'cfproperty cfquery cfqueryparam cfregistry cfreport cfreportparam cfrethrow cfreturn cfsavecontent cfschedule ' +
+					'cfscript cfsearch cfselect cfset cfsetting cfsilent cfslider cfsprydataset cfstoredproc cfswitch cftable ' +
+					'cftextarea cfthread cfthrow cftimer cftooltip cftrace cftransaction cftree cftreeitem cftry cfupdate cfwddx ' +
 					'cfwindow cfxml cfzip cfzipparam';
 
 	var operators =	'all and any between cross in join like not null or outer some';

--- a/syntaxhighlighter2/scripts/shBrushCpp.js
+++ b/syntaxhighlighter2/scripts/shBrushCpp.js
@@ -7,30 +7,30 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Cpp = function()
 {
 	// Copyright 2006 Shin, YoungJin
-	
+
 	var datatypes =	'ATOM BOOL BOOLEAN BYTE CHAR COLORREF DWORD DWORDLONG DWORD_PTR ' +
 					'DWORD32 DWORD64 FLOAT HACCEL HALF_PTR HANDLE HBITMAP HBRUSH ' +
 					'HCOLORSPACE HCONV HCONVLIST HCURSOR HDC HDDEDATA HDESK HDROP HDWP ' +
@@ -66,7 +66,7 @@ SyntaxHighlighter.brushes.Cpp = function()
 					'sizeof static static_cast struct switch template this ' +
 					'thread throw true false try typedef typeid typename union ' +
 					'using uuid virtual void volatile whcar_t while';
-					
+
 	var functions =	'assert isalnum isalpha iscntrl isdigit isgraph islower isprint' +
 					'ispunct isspace isupper isxdigit tolower toupper errno localeconv ' +
 					'setlocale acos asin atan atan2 ceil cos cosh exp fabs floor fmod ' +

--- a/syntaxhighlighter2/scripts/shBrushCss.js
+++ b/syntaxhighlighter2/scripts/shBrushCss.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -33,7 +33,7 @@ SyntaxHighlighter.brushes.CSS = function()
 	{
 		return '\\b([a-z_]|)' + str.replace(/ /g, '(?=:)\\b|\\b([a-z_\\*]|\\*|)') + '(?=:)\\b';
 	};
-	
+
 	function getValuesCSS(str)
 	{
 		return '\\b' + str.replace(/ /g, '(?!-)(?!:)\\b|\\b()') + '\:\\b';
@@ -70,7 +70,7 @@ SyntaxHighlighter.brushes.CSS = function()
 					'upper-roman url visible wait white wider w-resize x-fast x-high x-large x-loud x-low x-slow x-small x-soft xx-large xx-small yellow';
 
 	var fonts =		'[mM]onospace [tT]ahoma [vV]erdana [aA]rial [hH]elvetica [sS]ans-serif [sS]erif [cC]ourier mono sans serif';
-	
+
 	this.regexList = [
 		{ regex: SyntaxHighlighter.regexLib.multiLineCComments,		css: 'comments' },	// multiline comments
 		{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,		css: 'string' },	// double quoted strings
@@ -83,9 +83,9 @@ SyntaxHighlighter.brushes.CSS = function()
 		{ regex: new RegExp(this.getKeywords(fonts), 'g'),			css: 'color1' }		// fonts
 		];
 
-	this.forHtmlScript({ 
-		left: /(&lt;|<)\s*style.*?(&gt;|>)/gi, 
-		right: /(&lt;|<)\/\s*style\s*(&gt;|>)/gi 
+	this.forHtmlScript({
+		left: /(&lt;|<)\s*style.*?(&gt;|>)/gi,
+		right: /(&lt;|<)\/\s*style\s*(&gt;|>)/gi
 		});
 };
 

--- a/syntaxhighlighter2/scripts/shBrushDiff.js
+++ b/syntaxhighlighter2/scripts/shBrushDiff.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushErlang.js
+++ b/syntaxhighlighter2/scripts/shBrushErlang.js
@@ -7,30 +7,30 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Erlang = function()
 {
 	// Contributed by Jean-Lou Dupont
-	// http://jldupont.blogspot.com/2009/06/erlang-syntax-highlighter.html  
+	// http://jldupont.blogspot.com/2009/06/erlang-syntax-highlighter.html
 
 	// According to: http://erlang.org/doc/reference_manual/introduction.html#1.5
 	var keywords = 'after and andalso band begin bnot bor bsl bsr bxor '+

--- a/syntaxhighlighter2/scripts/shBrushGroovy.js
+++ b/syntaxhighlighter2/scripts/shBrushGroovy.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushJScript.js
+++ b/syntaxhighlighter2/scripts/shBrushJScript.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -44,7 +44,7 @@ SyntaxHighlighter.brushes.JScript = function()
 		{ regex: /\s*#.*/gm,										css: 'preprocessor' },		// preprocessor tags like #region and #endregion
 		{ regex: new RegExp(this.getKeywords(keywords), 'gm'),		css: 'keyword' }			// keywords
 		];
-	
+
 	this.forHtmlScript(SyntaxHighlighter.regexLib.scriptScriptTags);
 };
 

--- a/syntaxhighlighter2/scripts/shBrushJava.js
+++ b/syntaxhighlighter2/scripts/shBrushJava.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -50,8 +50,8 @@ SyntaxHighlighter.brushes.Java = function()
 		];
 
 	this.forHtmlScript({
-		left	: /(&lt;|<)%[@!=]?/g, 
-		right	: /%(&gt;|>)/g 
+		left	: /(&lt;|<)%[@!=]?/g,
+		right	: /%(&gt;|>)/g
 	});
 };
 

--- a/syntaxhighlighter2/scripts/shBrushJavaFX.js
+++ b/syntaxhighlighter2/scripts/shBrushJavaFX.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushPerl.js
+++ b/syntaxhighlighter2/scripts/shBrushPerl.js
@@ -7,56 +7,56 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Perl = function()
 {
 	// Contributed by David Simmons-Duffin and Marty Kube
-	
-	var funcs = 
-		'abs accept alarm atan2 bind binmode chdir chmod chomp chop chown chr ' + 
-		'chroot close closedir connect cos crypt defined delete each endgrent ' + 
-		'endhostent endnetent endprotoent endpwent endservent eof exec exists ' + 
-		'exp fcntl fileno flock fork format formline getc getgrent getgrgid ' + 
-		'getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr ' + 
-		'getnetbyname getnetent getpeername getpgrp getppid getpriority ' + 
-		'getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid ' + 
-		'getservbyname getservbyport getservent getsockname getsockopt glob ' + 
-		'gmtime grep hex index int ioctl join keys kill lc lcfirst length link ' + 
-		'listen localtime lock log lstat map mkdir msgctl msgget msgrcv msgsnd ' + 
-		'oct open opendir ord pack pipe pop pos print printf prototype push ' + 
-		'quotemeta rand read readdir readline readlink readpipe recv rename ' + 
-		'reset reverse rewinddir rindex rmdir scalar seek seekdir select semctl ' + 
-		'semget semop send setgrent sethostent setnetent setpgrp setpriority ' + 
-		'setprotoent setpwent setservent setsockopt shift shmctl shmget shmread ' + 
-		'shmwrite shutdown sin sleep socket socketpair sort splice split sprintf ' + 
-		'sqrt srand stat study substr symlink syscall sysopen sysread sysseek ' + 
-		'system syswrite tell telldir time times tr truncate uc ucfirst umask ' + 
+
+	var funcs =
+		'abs accept alarm atan2 bind binmode chdir chmod chomp chop chown chr ' +
+		'chroot close closedir connect cos crypt defined delete each endgrent ' +
+		'endhostent endnetent endprotoent endpwent endservent eof exec exists ' +
+		'exp fcntl fileno flock fork format formline getc getgrent getgrgid ' +
+		'getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr ' +
+		'getnetbyname getnetent getpeername getpgrp getppid getpriority ' +
+		'getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid ' +
+		'getservbyname getservbyport getservent getsockname getsockopt glob ' +
+		'gmtime grep hex index int ioctl join keys kill lc lcfirst length link ' +
+		'listen localtime lock log lstat map mkdir msgctl msgget msgrcv msgsnd ' +
+		'oct open opendir ord pack pipe pop pos print printf prototype push ' +
+		'quotemeta rand read readdir readline readlink readpipe recv rename ' +
+		'reset reverse rewinddir rindex rmdir scalar seek seekdir select semctl ' +
+		'semget semop send setgrent sethostent setnetent setpgrp setpriority ' +
+		'setprotoent setpwent setservent setsockopt shift shmctl shmget shmread ' +
+		'shmwrite shutdown sin sleep socket socketpair sort splice split sprintf ' +
+		'sqrt srand stat study substr symlink syscall sysopen sysread sysseek ' +
+		'system syswrite tell telldir time times tr truncate uc ucfirst umask ' +
 		'undef unlink unpack unshift utime values vec wait waitpid warn write';
-    
-	var keywords =  
+
+	var keywords =
 		'bless caller continue dbmclose dbmopen die do dump else elsif eval exit ' +
-		'for foreach goto if import last local my next no our package redo ref ' + 
+		'for foreach goto if import last local my next no our package redo ref ' +
 		'require return sub tie tied unless untie until use wantarray while';
-    
+
 	this.regexList = [
 		{ regex: new RegExp('#[^!].*$', 'gm'),					css: 'comments' },
 		{ regex: new RegExp('^\\s*#!.*$', 'gm'),				css: 'preprocessor' }, // shebang

--- a/syntaxhighlighter2/scripts/shBrushPhp.js
+++ b/syntaxhighlighter2/scripts/shBrushPhp.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -70,7 +70,7 @@ SyntaxHighlighter.brushes.Php = function()
 					'extends for foreach function include include_once global if ' +
 					'new old_function return static switch use require require_once ' +
 					'var while abstract interface public implements extends private protected throw';
-	
+
 	var constants	= '__FILE__ __LINE__ __METHOD__ __FUNCTION__ __CLASS__';
 
 	this.regexList = [

--- a/syntaxhighlighter2/scripts/shBrushPlain.js
+++ b/syntaxhighlighter2/scripts/shBrushPlain.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushPowerShell.js
+++ b/syntaxhighlighter2/scripts/shBrushPowerShell.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushPython.js
+++ b/syntaxhighlighter2/scripts/shBrushPython.js
@@ -7,30 +7,30 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Python = function()
 {
 	// Contributed by Gheorghe Milas and Ahmad Sherif
-	
+
 	var keywords =  'and assert break class continue def del elif else ' +
 					'except exec finally for from global if import in is ' +
 					'lambda not or pass print raise return try yield while';
@@ -58,7 +58,7 @@ SyntaxHighlighter.brushes.Python = function()
 			{ regex: new RegExp(this.getKeywords(keywords), 'gm'), 		css: 'keyword' },
 			{ regex: new RegExp(this.getKeywords(special), 'gm'), 		css: 'color1' }
 			];
-			
+
 	this.forHtmlScript(SyntaxHighlighter.regexLib.aspScriptTags);
 };
 

--- a/syntaxhighlighter2/scripts/shBrushRuby.js
+++ b/syntaxhighlighter2/scripts/shBrushRuby.js
@@ -7,30 +7,30 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Ruby = function()
 {
 	// Contributed by Erik Peterson.
-	
+
 	var keywords =	'alias and BEGIN begin break case class def define_method defined do each else elsif ' +
 					'END end ensure false for if in module new next nil not or raise redo rescue retry return ' +
 					'self super then throw true undef unless until when while yield';

--- a/syntaxhighlighter2/scripts/shBrushScala.js
+++ b/syntaxhighlighter2/scripts/shBrushScala.js
@@ -7,30 +7,30 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
 SyntaxHighlighter.brushes.Scala = function()
 {
 	// Contributed by Yegor Jbanov and David Bernard.
-	
+
 	var keywords =	'val sealed case def true trait implicit forSome import match object null finally super ' +
 	                'override try lazy for var catch throw type extends class while with new final yield abstract ' +
 	                'else do if return protected private this package false';

--- a/syntaxhighlighter2/scripts/shBrushSql.js
+++ b/syntaxhighlighter2/scripts/shBrushSql.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushVb.js
+++ b/syntaxhighlighter2/scripts/shBrushVb.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shBrushXml.js
+++ b/syntaxhighlighter2/scripts/shBrushXml.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -36,8 +36,8 @@ SyntaxHighlighter.brushes.Xml = function()
 			tag = new XRegExp('(&lt;|<)[\\s\\/\\?]*(?<name>[:\\w-\\.]+)', 'xg').exec(code),
 			result = []
 			;
-		
-		if (match.attributes != null) 
+
+		if (match.attributes != null)
 		{
 			var attributes,
 				regex = new XRegExp('(?<name> [\\w:\\-\\.]+)' +
@@ -45,7 +45,7 @@ SyntaxHighlighter.brushes.Xml = function()
 									'(?<value> ".*?"|\'.*?\'|\\w+)',
 									'xg');
 
-			while ((attributes = regex.exec(code)) != null) 
+			while ((attributes = regex.exec(code)) != null)
 			{
 				result.push(new constructor(attributes.name, match.index + attributes.index, 'color1'));
 				result.push(new constructor(attributes.value, match.index + attributes.index + attributes[0].indexOf(attributes.value), 'string'));
@@ -59,7 +59,7 @@ SyntaxHighlighter.brushes.Xml = function()
 
 		return result;
 	}
-	
+
 	this.regexList = [
 		{ regex: new XRegExp('(\\&lt;|<)\\!\\[[\\w\\s]*?\\[(.|\\s)*?\\]\\](\\&gt;|>)', 'gm'),			css: 'color2' },	// <![ ... [ ... ]]>
 		{ regex: SyntaxHighlighter.regexLib.xmlComments,												css: 'comments' },	// <!-- ... -->

--- a/syntaxhighlighter2/scripts/shCore.js
+++ b/syntaxhighlighter2/scripts/shCore.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/scripts/shLegacy.js
+++ b/syntaxhighlighter2/scripts/shLegacy.js
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */

--- a/syntaxhighlighter2/styles/shThemeDjango.css
+++ b/syntaxhighlighter2/styles/shThemeDjango.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -53,7 +53,7 @@
 	color: #B9BDB6 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -110,7 +110,7 @@
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #336442 !important;
 	font-style: italic !important;
 }
@@ -118,59 +118,59 @@
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #9DF39F !important; 
+	color: #9DF39F !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #96DD3B !important; 
+{
+	color: #96DD3B !important;
 	font-weight: bold !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #91BB9E !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #91BB9E !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #FFAA3E !important; 
+.syntaxhighlighter .variable
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #F7E741 !important; 
+{
+	color: #F7E741 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
-	color: #FFAA3E !important; 
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #E0E8FF !important; 
+{
+	color: #E0E8FF !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: #497958 !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #EB939A !important; 
+{
+	color: #EB939A !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #91BB9E !important; 
+{
+	color: #91BB9E !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: #EDEF7D !important; 
+{
+	color: #EDEF7D !important;
 }

--- a/syntaxhighlighter2/styles/shThemeEclipse.css
+++ b/syntaxhighlighter2/styles/shThemeEclipse.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -65,7 +65,7 @@
 	color: #000 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -103,74 +103,74 @@
  ************************************/
 .syntaxhighlighter .plain,
 .syntaxhighlighter .plain a
-{ 
+{
 	color: #000 !important;
 }
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #3f5fbf !important;
 }
 
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #2a00ff !important; 
+	color: #2a00ff !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #7f0055 !important; 
-	font-weight: bold !important; 
+{
+	color: #7f0055 !important;
+	font-weight: bold !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #646464 !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #646464 !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #a70 !important; 
+.syntaxhighlighter .variable
+{
+	color: #a70 !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #090 !important; 
+{
+	color: #090 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
-	color: #ff1493 !important; 
+{
+	color: #ff1493 !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #0066CC !important; 
+{
+	color: #0066CC !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: yellow !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #808080 !important; 
+{
+	color: #808080 !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #ff1493 !important; 
+{
+	color: #ff1493 !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: red !important; 
+{
+	color: red !important;
 }
 
 

--- a/syntaxhighlighter2/styles/shThemeEmacs.css
+++ b/syntaxhighlighter2/styles/shThemeEmacs.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -54,7 +54,7 @@
 	color: #B9BDB6 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -105,71 +105,71 @@
  ************************************/
 .syntaxhighlighter .plain,
 .syntaxhighlighter .plain a
-{ 
+{
 	color: #D3D3D3 !important;
 }
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #FF7D27 !important;
 }
 
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #FF9E7B !important; 
+	color: #FF9E7B !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #00FFFF !important; 
+{
+	color: #00FFFF !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #AEC4DE !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #AEC4DE !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #FFAA3E !important; 
+.syntaxhighlighter .variable
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #090 !important; 
+{
+	color: #090 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
-	color: #81CEF9 !important; 
+{
+	color: #81CEF9 !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #FF9E7B !important; 
+{
+	color: #FF9E7B !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: #990000 !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #EBDB8D !important; 
+{
+	color: #EBDB8D !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #FF7D27 !important; 
+{
+	color: #FF7D27 !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: #AEC4DE !important; 
+{
+	color: #AEC4DE !important;
 }

--- a/syntaxhighlighter2/styles/shThemeFadeToGrey.css
+++ b/syntaxhighlighter2/styles/shThemeFadeToGrey.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -54,7 +54,7 @@
 	color: #B9BDB6 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -105,73 +105,73 @@
  ************************************/
 .syntaxhighlighter .plain,
 .syntaxhighlighter .plain a
-{ 
+{
 	color: #FFFFFF !important;
 }
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #696854 !important;
 }
 
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #E3E658 !important; 
+	color: #E3E658 !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #D01D33 !important; 
+{
+	color: #D01D33 !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #435A5F !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #435A5F !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #898989 !important; 
+.syntaxhighlighter .variable
+{
+	color: #898989 !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #090 !important; 
+{
+	color: #090 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
+{
 	color: #AAAAAA !important;
 	font-weight: bold !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #96DAFF !important; 
+{
+	color: #96DAFF !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: #C3C3C3 !important;
 	color: #000 !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #FFC074 !important; 
+{
+	color: #FFC074 !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #4A8CDB !important; 
+{
+	color: #4A8CDB !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: #96DAFF !important; 
+{
+	color: #96DAFF !important;
 }

--- a/syntaxhighlighter2/styles/shThemeMidnight.css
+++ b/syntaxhighlighter2/styles/shThemeMidnight.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -54,7 +54,7 @@
 	color: #B9BDB6 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -105,71 +105,71 @@
  ************************************/
 .syntaxhighlighter .plain,
 .syntaxhighlighter .plain a
-{ 
+{
 	color: #D1EDFF !important;
 }
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #428BDD !important;
 }
 
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #1DC116 !important; 
+	color: #1DC116 !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #B43D3D !important; 
+{
+	color: #B43D3D !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #8AA6C1 !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #8AA6C1 !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #FFAA3E !important; 
+.syntaxhighlighter .variable
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #F7E741 !important; 
+{
+	color: #F7E741 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
-	color: #FFAA3E !important; 
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #E0E8FF !important; 
+{
+	color: #E0E8FF !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: #404040 !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #F8BB00 !important; 
+{
+	color: #F8BB00 !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #FFFFFF !important; 
+{
+	color: #FFFFFF !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: #FFAA3E !important; 
+{
+	color: #FFAA3E !important;
 }

--- a/syntaxhighlighter2/styles/shThemeRDark.css
+++ b/syntaxhighlighter2/styles/shThemeRDark.css
@@ -7,23 +7,23 @@
  *
  * @version
  * 2.1.364 (October 15 2009)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2009 Alex Gorbatchev.
  *
  * @license
  * This file is part of SyntaxHighlighter.
- * 
+ *
  * SyntaxHighlighter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SyntaxHighlighter is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with SyntaxHighlighter.  If not, see <http://www.gnu.org/copyleft/lesser.html>.
  */
@@ -54,7 +54,7 @@
 	color: #B9BDB6 !important;
 }
 
-.syntaxhighlighter.printing .line .content 
+.syntaxhighlighter.printing .line .content
 {
 	border: 0 !important;
 }
@@ -105,71 +105,71 @@
  ************************************/
 .syntaxhighlighter .plain,
 .syntaxhighlighter .plain a
-{ 
+{
 	color: #B9BDB6 !important;
 }
 
 .syntaxhighlighter .comments,
 .syntaxhighlighter .comments a
-{ 
+{
 	color: #878A85 !important;
 }
 
 .syntaxhighlighter .string,
 .syntaxhighlighter .string a
 {
-	color: #5CE638 !important; 
+	color: #5CE638 !important;
 }
 
 .syntaxhighlighter .keyword
-{ 
-	color: #5BA1CF !important; 
+{
+	color: #5BA1CF !important;
 }
 
-.syntaxhighlighter .preprocessor 
-{ 
-	color: #435A5F !important; 
+.syntaxhighlighter .preprocessor
+{
+	color: #435A5F !important;
 }
 
-.syntaxhighlighter .variable 
-{ 
-	color: #FFAA3E !important; 
+.syntaxhighlighter .variable
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .value
-{ 
-	color: #090 !important; 
+{
+	color: #090 !important;
 }
 
 .syntaxhighlighter .functions
-{ 
-	color: #FFAA3E !important; 
+{
+	color: #FFAA3E !important;
 }
 
 .syntaxhighlighter .constants
-{ 
-	color: #E0E8FF !important; 
+{
+	color: #E0E8FF !important;
 }
 
 .syntaxhighlighter .script
-{ 
+{
 	background-color: #435A5F !important;
 }
 
 .syntaxhighlighter .color1,
 .syntaxhighlighter .color1 a
-{ 
-	color: #E0E8FF !important; 
+{
+	color: #E0E8FF !important;
 }
 
 .syntaxhighlighter .color2,
 .syntaxhighlighter .color2 a
-{ 
-	color: #FFFFFF !important; 
+{
+	color: #FFFFFF !important;
 }
 
 .syntaxhighlighter .color3,
 .syntaxhighlighter .color3 a
-{ 
-	color: #FFAA3E !important; 
+{
+	color: #FFAA3E !important;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just updates line ending in some files. It was causing some issues to add the file to SVN.

### Testing instructions

* Go to wp-admin > Settings > SyntaxHighlighter.
* Update the option _"Highlighter Version"_ to _"Version 2.x"_.
* Test if the code continue formatted in the frontend.