### PR TITLE
Add syntax highlight for Haskell

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -138,6 +138,7 @@ class SyntaxHighlighter {
 		wp_register_script( 'syntaxhighlighter-brush-erlang',     plugins_url( $this->shfolder . '/scripts/shBrushErlang.js',     __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-go',         plugins_url( $this->shfolder . '/scripts/shBrushGo.js',         __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-groovy',     plugins_url( $this->shfolder . '/scripts/shBrushGroovy.js',     __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
+		wp_register_script( 'syntaxhighlighter-brush-haskell',    plugins_url( $this->shfolder . '/scripts/shBrushHaskell.js',    __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-java',       plugins_url( $this->shfolder . '/scripts/shBrushJava.js',       __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-javafx',     plugins_url( $this->shfolder . '/scripts/shBrushJavaFX.js',     __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_script( 'syntaxhighlighter-brush-jscript',    plugins_url( $this->shfolder . '/scripts/shBrushJScript.js',    __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
@@ -201,6 +202,7 @@ class SyntaxHighlighter {
 			'go'            => 'go',
 			'golang'        => 'go',
 			'groovy'        => 'groovy',
+			'haskell'       => 'haskell',
 			'java'          => 'java',
 			'jfx'           => 'javafx',
 			'javafx'        => 'javafx',
@@ -256,6 +258,7 @@ class SyntaxHighlighter {
 			'fsharp'     => __( 'F#',                        'syntaxhighlighter' ),
 			'go'         => __( 'Go',                        'syntaxhighlighter' ),
 			'groovy'     => __( 'Groovy',                    'syntaxhighlighter' ),
+			'haskell'    => __( 'Haskell',                   'syntaxhighlighter' ),
 			'java'       => __( 'Java',                      'syntaxhighlighter' ),
 			'javafx'     => __( 'JavaFX',                    'syntaxhighlighter' ),
 			'jscript'    => __( 'JavaScript',                'syntaxhighlighter' ),

--- a/syntaxhighlighter3/scripts/shBrushHaskell.js
+++ b/syntaxhighlighter3/scripts/shBrushHaskell.js
@@ -1,0 +1,38 @@
+/**
+ * Haskell Brushes for SyntaxHighlighter 3.0
+ */
+(function () {
+	// CommonJS
+	SyntaxHighlighter = SyntaxHighlighter || (typeof require !== 'undefined'? require('shCore').SyntaxHighlighter : null);
+
+	function Brush() {
+		var keywords = 'as case of class data default deriving do forall foreign hiding ' +
+			'if then else import instance let in mdo module newtype qualified type where';
+
+		this.regexList = [
+			{ regex: /{-#[\s\S]*?#-}/g,                                 css: 'preprocessor' },
+			{ regex: /--.*/g,                                           css: 'comments' },      // one line comments
+			{ regex: /{-(?!\$)[\s\S]*?-}/gm,                            css: 'comments' },      // multiline comments
+			{ regex: /'.'/g,                                            css: 'string' },        // chars
+			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,     css: 'string' },        // strings
+			{ regex: /(-|!|#|\$|%|&amp;|\*|\+|\/|&lt;|=|&gt;|\?|@|\^|\||~|:|\.|\\)+/g, css: 'keyword bold' },
+			{ regex: /`[a-z][a-z0-9_']*`/g,                             css: 'keyword bold' },  // infix operators
+			{ regex: /\b(\d+|0x[0-9a-f]+)\b/gi,                         css: 'value' },         // integer
+			{ regex: /\b\d+(\.\d*)?([eE][+-]?\d+)?\b/gi,                css: 'value' },         // floating number
+			{ regex: new RegExp(this.getKeywords(keywords), 'gm'),      css: 'keyword bold' }
+		];
+
+		this.forHtmlScript({
+			left	: /(&lt;|<)%[@!=]?/g, 
+			right	: /%(&gt;|>)/g 
+		});
+	}
+
+	Brush.prototype = new SyntaxHighlighter.Highlighter();
+	Brush.aliases   = ['haskell'];
+
+	SyntaxHighlighter.brushes.Haskell = Brush;
+
+	// CommonJS
+	typeof exports != 'undefined' ? (exports.Brush = Brush) : null;
+})();


### PR DESCRIPTION
Inspired by #53

### Changes proposed in this Pull Request

* Add support for Haskell

### Testing instructions

1. Add syntaxhighlighter block
1. Select Haskell as a language
1. Copy paste some code from https://github.com/bor0/misc/blob/master/2021/Haskelogic/Gentzen.hs
1. Save and preview
1. Make sure its syntax highlighted

### Screenshot / Video

`wp-admin`:
<img width="438" alt="Screenshot 2021-04-09 at 12 50 58" src="https://user-images.githubusercontent.com/1620929/114169756-4762bd80-9932-11eb-8022-67285965f711.png">

Frontend:
<img width="481" alt="Screenshot 2021-04-09 at 12 51 02" src="https://user-images.githubusercontent.com/1620929/114169760-4893ea80-9932-11eb-94ef-8a32f6e89035.png">
