### PR TITLE
Set code block language when pasting into editor

### DIFF
--- a/src/code-block/transforms.js
+++ b/src/code-block/transforms.js
@@ -21,6 +21,16 @@ export default {
 				node.children.length === 1 &&
 				node.firstChild.nodeName === 'CODE'
 			),
+			transform( node ) {
+				const content = node.firstChild.textContent;
+				const [ startingMatch, language ] = content.match( /^```(\w+)?\n/ ) || [ null, null ];
+				const attributes = language ? { language } : {};
+
+				// Extract content without backticks and (optionally) language.
+				attributes.content = startingMatch ? content.replace( startingMatch, '' ).replace( /```$/, '' ) : content;
+
+				return createBlock( 'syntaxhighlighter/code', attributes );
+			},
 			schema: {
 				pre: {
 					children: {

--- a/src/code-block/transforms.js
+++ b/src/code-block/transforms.js
@@ -27,7 +27,7 @@ export default {
 				const attributes = language ? { language } : {};
 
 				// Extract content without backticks and (optionally) language.
-				attributes.content = startingMatch ? content.replace( startingMatch, '' ).replace( /```$/, '' ) : content;
+				attributes.content = startingMatch ? content.replace( startingMatch, '' ).replace( /```\s*$/, '' ) : content;
 
 				return createBlock( 'syntaxhighlighter/code', attributes );
 			},


### PR DESCRIPTION
Fixes #125.

### Changes proposed in this Pull Request

Adds support for language when pasting code into the block editor.

### Testing instructions

Test with the following snippets and ensure the language in the block toolbar is set appropriately. The starting and ending backticks, as well as the language, should not appear as part of the code block content:

    ```python
    call_function()

    if some_condition:
        do_something()
    ```
And:

    ```css
    #button {
      border: none;
    }
    ```

Also test without the language parameter. The backticks should still be removed:

    ```
    #button {
      border: none;
    }
    ```