### PR TITLE
Add "color: initial" to preserve black color

### DIFF
--- a/src/code-block/editor.scss
+++ b/src/code-block/editor.scss
@@ -1,1 +1,6 @@
 @import '../toolbar-dropdown/style'
+
+// to override the "color: inherit" value set here https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/plain-text/style.scss#L5
+.wp-block-syntaxhighlighter__textarea {
+    color: initial;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Add "color: initial" to preserve black color inside block-editor-plain-text block

Fixes https://github.com/Automattic/themes/issues/3617

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

### Before
![image](https://user-images.githubusercontent.com/17054134/128040862-786d763c-8695-41e7-944f-1c4c43686bfe.png)

### After
![image](https://user-images.githubusercontent.com/17054134/128040989-fe6d6197-3648-4c07-96bd-2477448cb4f9.png)

