### PR TITLE
Display the list of available brushes

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1600,7 +1600,7 @@ class SyntaxHighlighter {
 						),
 						'<code>lang</code>',
 						'<code>language</code>',
-						implode(', ', array_keys($this->brushes))
+						implode( ', ', array_keys( $this->brushes ) )
 					),
 					array(
 						'a' => array(

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1594,13 +1594,13 @@ class SyntaxHighlighter {
 					sprintf(
 						// translators: %1$s Lang parameter; %2$s Language parameter; %3$s Valid tags link.
 						_x(
-							'%1$s or %2$s &#8212; The language syntax to highlight with. You can alternately just use that as the tag, such as <code>[php]code[/php]</code>. <a href="%3$s">Click here</a> for a list of valid tags (under &quot;aliases&quot;).',
+							'%1$s or %2$s &#8212; The language syntax to highlight with. You can alternately just use that as the tag, such as <code>[php]code[/php]</code>. Available tags: %3$s.',
 							'language parameter',
 							'syntaxhighlighter'
 						),
 						'<code>lang</code>',
 						'<code>language</code>',
-						'http://alexgorbatchev.com/SyntaxHighlighter/manual/brushes/'
+						implode(', ', array_keys($this->brushes))
 					),
 					array(
 						'a' => array(

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1592,7 +1592,7 @@ class SyntaxHighlighter {
 			<?php
 				echo wp_kses(
 					sprintf(
-						// translators: %1$s Lang parameter; %2$s Language parameter; %3$s Valid tags link.
+						// translators: %1$s Lang parameter; %2$s Language parameter; %3$s List of brush names.
 						_x(
 							'%1$s or %2$s &#8212; The language syntax to highlight with. You can alternately just use that as the tag, such as <code>[php]code[/php]</code>. Available tags: %3$s.',
 							'language parameter',


### PR DESCRIPTION
These brushes could be used as shortcodes instead of passing them to lang property.

Previously, this list was available on the external website but now is not reachable anymore.

Fixes #207 

### Changes proposed in this Pull Request

* Remove external link (the website redirects to another project now).
* Add a list of available tags.

### Testing instructions

* Install and activate SyntaxHighlighter Evolved.
* Go to Settings -> SyntaxHighlighter.
* Find Shortcode Parameters.

### Screenshot / Video
Before:
<img width="1174" alt="CleanShot 2021-11-15 at 13 59 19@2x" src="https://user-images.githubusercontent.com/329356/141770507-4aecd28e-087f-4ba4-b204-0878e59a0b0f.png">

After:
<img width="1522" alt="CleanShot 2021-11-15 at 13 52 54@2x" src="https://user-images.githubusercontent.com/329356/141770253-31067cb6-c560-461b-9a7d-0b078c8379da.png">




