### PR TITLE
Fix line alignment for bootstrap themes

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -7,7 +7,7 @@
  *
  * @version
  * 3.0.83 (July 02 2010)
- * 
+ *
  * @copyright
  * Copyright (C) 2004-2010 Alex Gorbatchev.
  *
@@ -94,6 +94,11 @@
 }
 .syntaxhighlighter table td.code .container {
   position: relative !important;
+}
+.syntaxhighlighter table td.code .container:after,
+.syntaxhighlighter table td.code .container:before {
+  display: block !important;
+  content: "";
 }
 .syntaxhighlighter table td.code .container textarea {
   box-sizing: border-box !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -95,6 +95,9 @@
 .syntaxhighlighter table td.code .container {
   position: relative !important;
 }
+/**
+ * The following rule was added to resolve conflict with themes that use Bootstrap CSS.
+ */
 .syntaxhighlighter table td.code .container:after,
 .syntaxhighlighter table td.code .container:before {
   display: block !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -96,7 +96,7 @@
   position: relative !important;
 }
 /**
- * The following rule was added to resolve conflict with themes that use Bootstrap CSS.
+ * Resolve conflict with Bootstrap CSS-based themes.
  */
 .syntaxhighlighter table td.code .container:after,
 .syntaxhighlighter table td.code .container:before {


### PR DESCRIPTION
Remove styling for the code container that Bootstrap accidentally adds.

Bootstrap has its own containers but it applies styles for all containers.

Fixes #192 

### Changes proposed in this Pull Request

* Remove styling for the code container that was added by Bootstrap

### Testing instructions

* Add a SyntaxHighlighter to the post with at least one line of code.
* Open the post on the frontend.

### Screenshot / Video
Before:
<img width="613" alt="CleanShot 2021-11-16 at 11 48 06@2x" src="https://user-images.githubusercontent.com/329356/141953370-18d75011-3913-4b6a-838a-556244b6ec15.png">

After:
<img width="602" alt="CleanShot 2021-11-16 at 11 44 55@2x" src="https://user-images.githubusercontent.com/329356/141953305-55d4a58a-d95b-4227-ac5c-e2976ca45c35.png">



