### PR TITLE
Add space around code

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -65,6 +65,7 @@
   overflow: auto !important;
   overflow-y: hidden !important;
   font-size: 1em !important;
+  padding: 0.5em 1em !important;
 }
 .syntaxhighlighter code {
   display: inline !important;
@@ -91,7 +92,6 @@
 }
 .syntaxhighlighter table td.code {
   width: 100% !important;
-  padding: 1em !important;
 }
 .syntaxhighlighter table td.code .container {
   position: relative !important;
@@ -119,10 +119,11 @@
 }
 .syntaxhighlighter table td.gutter .line {
   text-align: right !important;
-  padding: 0 0.5em 0 1em !important;
+  padding: 0 0.5em 0 0 !important;
+  margin-right: 1em !important;
 }
 .syntaxhighlighter table td.code .line {
-  padding: 0 1em !important;
+  padding: 0 !important;
 }
 .syntaxhighlighter.nogutter td.code .container textarea, .syntaxhighlighter.nogutter td.code .line {
   padding-left: 0em !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -91,6 +91,7 @@
 }
 .syntaxhighlighter table td.code {
   width: 100% !important;
+  padding: 1em !important;
 }
 .syntaxhighlighter table td.code .container {
   position: relative !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -88,7 +88,7 @@
 }
 .syntaxhighlighter table caption {
   text-align: left !important;
-  padding: .5em 0 0.5em 1em !important;
+  padding: 0 0 0.5em 0 !important;
 }
 .syntaxhighlighter table td.code {
   width: 100% !important;


### PR DESCRIPTION
Fixes #168 #131 

### Changes proposed in this Pull Request

* Add some space around code

### Testing instructions

* Add a code block with an underscore on the last line (it might be a single line of code) to a post
* Preview the post on Linux with Firefox (for me  Ubuntu 20.04 and Firefox 90.0)

### Screenshot / Video
Before:
<img width="692" alt="CleanShot 2021-11-16 at 15 22 02@2x" src="https://user-images.githubusercontent.com/329356/141984875-98333ad7-8996-40f0-af4c-f0e8bf756832.png">
<img width="927" alt="CleanShot 2021-11-16 at 15 22 49@2x" src="https://user-images.githubusercontent.com/329356/141984896-9ecad9a8-3bb5-414a-aa77-a206bb0b8a47.png">

After:
<img width="672" alt="CleanShot 2021-11-16 at 15 17 44@2x" src="https://user-images.githubusercontent.com/329356/141984940-0ec094c8-b9d6-48c4-9415-dad82b0b206c.png">
<img width="893" alt="CleanShot 2021-11-16 at 15 17 23@2x" src="https://user-images.githubusercontent.com/329356/141984946-db35bb88-15ca-4ef4-a610-5e8e7d0c55ca.png">

