### PR TITLE
Prepare release archive using composer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.yml]
+[*.{yml,json}]
 indent_style = space
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 dist/
 node_modules
+/vendor/
+/*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ before_script:
           exit 1
           ;;
       esac
+    composer global require "yoast/phpunit-polyfills:^1.0"
     fi
   - |
     # Install PHP_CodeSniffer if it's requested for this test

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-  "name": "automattic/syntaxhighlighter",
-  "description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
-  "type": "wordpress-plugin",
-  "license": "GPL-2.0-or-later",
-  "require": {},
-  "archive": {
-	"exclude": [
-	  "/*",
-	  "!/dist",
-	  "!/syntaxhighlighter2",
-	  "!/syntaxhighlighter3",
-	  "!/third-party-brushes",
-	  "!/syntaxhighlighter_mce-4.js",
-	  "!/syntaxhighlighter_mce.js",
-	  "!/syntaxhighlighter.js",
-	  "!/syntaxhighlighter.php",
-	  "!/readme.txt",
-	  ".DS_Store",
-	  ".*",
-	  "*.test.js"
-	]
-  }
+	"name": "automattic/syntaxhighlighter",
+	"description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"archive": {
+		"exclude": [
+			"/*",
+			"!/dist",
+			"!/syntaxhighlighter2",
+			"!/syntaxhighlighter3",
+			"!/third-party-brushes",
+			"!/syntaxhighlighter_mce-4.js",
+			"!/syntaxhighlighter_mce.js",
+			"!/syntaxhighlighter.js",
+			"!/syntaxhighlighter.php",
+			"!/readme.txt",
+			".DS_Store",
+			".*",
+			"*.test.js"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "automattic/syntaxhighlighter",
+  "description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {},
+  "archive": {
+	"exclude": [
+	  "/*",
+	  "!/dist",
+	  "!/syntaxhighlighter2",
+	  "!/syntaxhighlighter3",
+	  "!/third-party-brushes",
+	  "!/syntaxhighlighter_mce-4.js",
+	  "!/syntaxhighlighter_mce.js",
+	  "!/syntaxhighlighter.js",
+	  "!/syntaxhighlighter.php",
+	  "!/readme.txt",
+	  ".DS_Store",
+	  ".*",
+	  "*.test.js"
+	]
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-	"name": "automattic/syntaxhighlighter",
-	"description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
-	"type": "wordpress-plugin",
-	"license": "GPL-2.0-or-later",
-	"require": {},
-	"archive": {
-		"exclude": [
-			"/*",
-			"!/dist",
-			"!/syntaxhighlighter2",
-			"!/syntaxhighlighter3",
-			"!/third-party-brushes",
-			"!/syntaxhighlighter_mce-4.js",
-			"!/syntaxhighlighter_mce.js",
-			"!/syntaxhighlighter.js",
-			"!/syntaxhighlighter.php",
-			"!/readme.txt",
-			".DS_Store",
-			".*",
-			"*.test.js"
-		]
-	}
+  "name": "automattic/syntaxhighlighter",
+  "description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {},
+  "archive": {
+    "exclude": [
+      "/*",
+      "!/dist",
+      "!/syntaxhighlighter2",
+      "!/syntaxhighlighter3",
+      "!/third-party-brushes",
+      "!/syntaxhighlighter_mce-4.js",
+      "!/syntaxhighlighter_mce.js",
+      "!/syntaxhighlighter.js",
+      "!/syntaxhighlighter.php",
+      "!/readme.txt",
+      ".DS_Store",
+      ".*",
+      "*.test.js"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
 		"start": "cgb-scripts start",
 		"build": "cgb-scripts build",
 		"distclean": "rm -rf node_modules && rm -rf dist",
-		"preinstall": "npx npm-force-resolutions"
+		"preinstall": "npx npm-force-resolutions",
+	    "archive": "composer archive --file=$npm_package_name --format=zip",
+	    "release": "npm run build && npm run archive"
 	},
 	"dependencies": {
 		"@wordpress/escape-html": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "syntaxhighlighter",
-	"version": "3.6.0",
-	"description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
-	"homepage": "https://alex.blog/wordpress-plugins/syntaxhighlighter/",
-	"author": "Alex Mills (Viper007Bond)",
-	"license": "GPL-2.0-or-later",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/Viper007Bond/syntaxhighlighter.git"
-	},
-	"bugs": {
-		"url": "https://github.com/Viper007Bond/syntaxhighlighter/issues"
-	},
-	"scripts": {
-		"start": "cgb-scripts start",
-		"build": "cgb-scripts build",
-		"distclean": "rm -rf node_modules && rm -rf dist",
-		"preinstall": "npx npm-force-resolutions",
-		"archive": "composer archive --file=$npm_package_name --format=zip",
-		"release": "npm run build && npm run archive"
-	},
-	"dependencies": {
-		"@wordpress/escape-html": "1.9.0",
-		"cgb-scripts": "1.23.0",
-		"classnames": "2.2.6",
-		"lodash.unescape": "4.0.1",
-		"npm-force-resolutions": "0.0.3"
-	},
-	"resolutions": {
-		"mem": "4.0.0"
-	}
+  "name": "syntaxhighlighter",
+  "version": "3.6.0",
+  "description": "Easily post syntax-highlighted code to your WordPress site without having to modify the code at all.",
+  "homepage": "https://alex.blog/wordpress-plugins/syntaxhighlighter/",
+  "author": "Alex Mills (Viper007Bond)",
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Viper007Bond/syntaxhighlighter.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Viper007Bond/syntaxhighlighter/issues"
+  },
+  "scripts": {
+    "start": "cgb-scripts start",
+    "build": "cgb-scripts build",
+    "distclean": "rm -rf node_modules && rm -rf dist",
+    "preinstall": "npx npm-force-resolutions",
+    "archive": "composer archive --file=$npm_package_name --format=zip",
+    "release": "npm run build && npm run archive"
+  },
+  "dependencies": {
+    "@wordpress/escape-html": "1.9.0",
+    "cgb-scripts": "1.23.0",
+    "classnames": "2.2.6",
+    "lodash.unescape": "4.0.1",
+    "npm-force-resolutions": "0.0.3"
+  },
+  "resolutions": {
+    "mem": "4.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   },
   "scripts": {
     "start": "cgb-scripts start",
-    "build": "cgb-scripts build",
+    "build": "npm run build:assets && npm run archive",
+    "build:assets": "cgb-scripts build",
     "distclean": "rm -rf node_modules && rm -rf dist",
     "preinstall": "npx npm-force-resolutions",
-    "archive": "composer archive --file=$npm_package_name --format=zip",
-    "release": "npm run build && npm run archive"
+    "archive": "composer archive --file=$npm_package_name --format=zip"
   },
   "dependencies": {
     "@wordpress/escape-html": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 		"build": "cgb-scripts build",
 		"distclean": "rm -rf node_modules && rm -rf dist",
 		"preinstall": "npx npm-force-resolutions",
-	    "archive": "composer archive --file=$npm_package_name --format=zip",
-	    "release": "npm run build && npm run archive"
+		"archive": "composer archive --file=$npm_package_name --format=zip",
+		"release": "npm run build && npm run archive"
 	},
 	"dependencies": {
 		"@wordpress/escape-html": "1.9.0",


### PR DESCRIPTION
Fixes #147 

### Changes proposed in this Pull Request

* Adds `composer.json` config.
* Adds `archive` and `release` scripts for `npm`.
* Adds `.zip` and `/vendor` to `.gitignore`.

### Testing instructions

* Run `composer install` and `npm install`
* Run `npm run release`
* Chech directory for the `syntaxhighlighter.zip`
