### PR TITLE
Fix XML brush: use the last occurrence of the tag

### DIFF
--- a/syntaxhighlighter3/scripts/shBrushXml.js
+++ b/syntaxhighlighter3/scripts/shBrushXml.js
@@ -48,7 +48,7 @@
 
 			if (tag != null)
 				result.push(
-					new constructor(tag.name, match.index + tag[0].indexOf(tag.name), 'keyword')
+					new constructor(tag.name, match.index + tag[0].lastIndexOf(tag.name), 'keyword')
 				);
 
 			return result;


### PR DESCRIPTION
Fixes #143 

The solution was suggested in the issue.

### Changes proposed in this Pull Request

* Use `lastIndexOf`instead of `indexOf`: for some tags, it becomes vital to get the last occurrence. As we have encoded HTML entities (for example, `<` as `&lt;`), some tags become a representation where the tag name appears a few times. For example `<l>` looks like `&lt;l&gt;`. And the first position of the tag name (`l`) is `1` which refers to the HTML entity, but we need to get the last appearance: `4`.

### Testing instructions

* Add a shortcode to a post:
  ```
  [code lang="XML"]
  <l name="John" />
  <t name="Doe" />
  [/code]
  ```
* Preview the post 
  
### Screenshot / Video
Before:
<img width="909" alt="CleanShot 2021-11-23 at 01 14 54@2x" src="https://user-images.githubusercontent.com/329356/142943105-74e488b6-1bb3-4787-a4d6-8cf904bcc32d.png">

After:
<img width="901" alt="CleanShot 2021-11-23 at 01 14 18@2x" src="https://user-images.githubusercontent.com/329356/142943115-f67e9149-1ac0-482a-8a5c-69ad40b3adb7.png">
