### PR TITLE
Fix Language is not set when language alias does not exist.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6881,18 +6881,11 @@
           "requires": {
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "mem": "4.0.0"
           },
           "dependencies": {
             "mem": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-              "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
-              "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^1.0.0",
-                "p-is-promise": "^1.1.0"
-              }
+              "version": "4.0.0"
             }
           }
         },

--- a/src/code-block/transforms.js
+++ b/src/code-block/transforms.js
@@ -9,8 +9,8 @@ export default {
 			regExp: /^```\w*$/,
 			transform: ( { content = '' } ) => {
 				const [ , language ] = content.match( /^```(\w+)/ ) || [ null, null ];
-
-				const attributes = language ? { language } : undefined;
+				const { brushes } = window.syntaxHighlighterData;
+				const attributes = language && brushes[ language ] ? { language } : { language: 'plain' };
 				return createBlock( 'syntaxhighlighter/code', attributes );
 			},
 		},


### PR DESCRIPTION
Reported in the gutenberg repository issue:
https://github.com/WordPress/gutenberg/issues/41623

### Changes proposed in this Pull Request

This PR adds fallback when a non-existent alias (`brush`) is entered by **``` + enter**.

### Screenshot / Video

If a block is created by a non-existent alias, the language is not set correctly in the toolbar.
Also, clicking a blank button causes the block to crash.

https://user-images.githubusercontent.com/54422211/173046664-cdc6bf69-7f5d-4caf-a59d-3b0c9cf3f841.mp4

### Testing instructions

`Plain Text` is now set as the language as a fallback when a non-existent alias is specified.

My concern is that when `plain` key is excluded by the `syntaxhighlighter_brushes` filter, it will probably cause the same error.
Another way to handle this might be to not generate a block when a non-existent alias is specified.