### PR TITLE
Add TypeScript syntax highlighting

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -162,6 +162,7 @@ class SyntaxHighlighter {
 		wp_register_script( 'syntaxhighlighter-brush-matlabkey',  plugins_url( 'third-party-brushes/shBrushMatlabKey.js',         __FILE__ ), array( 'syntaxhighlighter-core' ), '20091209'     );
 		wp_register_script( 'syntaxhighlighter-brush-objc',       plugins_url( 'third-party-brushes/shBrushObjC.js',              __FILE__ ), array( 'syntaxhighlighter-core' ), '20091207'     );
 		wp_register_script( 'syntaxhighlighter-brush-r',          plugins_url( 'third-party-brushes/shBrushR.js',                 __FILE__ ), array( 'syntaxhighlighter-core' ), '20100919'     );
+		wp_register_script( 'syntaxhighlighter-brush-ts',         plugins_url( 'third-party-brushes/shBrushTs.js',                __FILE__ ), array( 'syntaxhighlighter-core' ), '20160926'     );
 
 		// Register theme stylesheets
 		wp_register_style( 'syntaxhighlighter-core',             plugins_url( $this->shfolder . '/styles/shCore.css',            __FILE__ ), array(),                           $this->agshver );
@@ -231,6 +232,8 @@ class SyntaxHighlighter {
 			'rb'            => 'ruby',
 			'ror'           => 'ruby',
 			'ruby'          => 'ruby',
+			'ts'            => 'ts',
+			'typescript'    => 'ts',
 			'scala'         => 'scala',
 			'sql'           => 'sql',
 			'swift'         => 'swift',
@@ -277,6 +280,7 @@ class SyntaxHighlighter {
 			'scala'      => __( 'Scala',                     'syntaxhighlighter' ),
 			'swift'      => __( 'Swift',                     'syntaxhighlighter' ),
 			'sql'        => __( 'SQL',                       'syntaxhighlighter' ),
+			'ts'         => __( 'TypeScript',                'syntaxhighlighter' ),
 			'vb'         => __( 'Visual Basic',              'syntaxhighlighter' ),
 			'xml'        => __( 'HTML / XHTML / XML / XSLT', 'syntaxhighlighter' ),
 			'yaml'        => __( 'YAML',                     'syntaxhighlighter' ),

--- a/third-party-brushes/shBrushTs.js
+++ b/third-party-brushes/shBrushTs.js
@@ -1,0 +1,38 @@
+SyntaxHighlighter.brushes.ts = function () {
+	const keywords =
+		"break case catch class continue " +
+		"default delete do else enum export extends false  " +
+		"for function if implements import in instanceof " +
+		"interface let new null package private protected " +
+		"static return super switch " +
+		"this throw true try typeof var while with yield" +
+		" any bool declare get module never number public readonly set string"; // TypeScript-specific, everything above is common with JavaScript
+
+	this.regexList = [
+		{
+			regex: SyntaxHighlighter.regexLib.multiLineDoubleQuotedString,
+			css: "string",
+		},
+		{
+			regex: SyntaxHighlighter.regexLib.multiLineSingleQuotedString,
+			css: "string",
+		},
+		{
+			regex: SyntaxHighlighter.regexLib.singleLineCComments,
+			css: "comments",
+		},
+		{
+			regex: SyntaxHighlighter.regexLib.multiLineCComments,
+			css: "comments",
+		},
+		{
+			regex: new RegExp(this.getKeywords(keywords), "gm"),
+			css: "keyword",
+		},
+	];
+
+	this.forHtmlScript(SyntaxHighlighter.regexLib.scriptScriptTags);
+};
+
+SyntaxHighlighter.brushes.ts.prototype = new SyntaxHighlighter.Highlighter();
+SyntaxHighlighter.brushes.ts.aliases = ["ts", "typescript"];


### PR DESCRIPTION
### Changes proposed in this Pull Request

Add TypeScript syntax.

Add brush based on:
https://github.com/syntaxhighlighter/brush-typescript/blob/07d5fa0a57527d2f11d601676ea68a6ab91d3e6d/brush.js

Fixes #214

Work in progress, the brush seems to have some issues.

### Testing instructions

*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
