### PR TITLE
Update the "Tested up to" after testing in WordPress 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Viper007Bond, automattic, donncha
 Donate link: https://alex.blog/2019/03/13/in-memory-of-alex-donation-link-update/
 Tags: code, source, sourcecode, php, syntax highlighting, syntax, highlight, highlighting, highlighter, WordPress.com
 Requires at least: 5.7
-Tested up to: 5.9
+Tested up to: 6.2
 Stable tag: 3.6.2
 
 Easily post syntax-highlighted code to your site without having to modify the code at all. As seen on WordPress.com.

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -12,7 +12,7 @@ Text Domain:  syntaxhighlighter
 License:      GPL2
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 5.7
-Tested up to: 5.9
+Tested up to: 6.2
 Requires PHP: 7.0
 
 **************************************************************************/


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just updates the "Tested up to" after testing in WordPress 6.2.
  * I'm updating it for parity, but I'm also updating it directly in the published plugin code without a release.