### PR TITLE
Fix nested shortcode bugs

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -659,8 +659,8 @@ class SyntaxHighlighter {
 			return $content;
 		}
 
-		// Backup current registered shortcodes and clear them all out
-		$orig_shortcode_tags = $shortcode_tags;
+		// Backup current registered shortcodes and clear them all out (we do not backup our own, because we will add and parse them below)
+		$orig_shortcode_tags = array_diff_key( $shortcode_tags, array_flip( $this->shortcodes ) );
 		remove_all_shortcodes();
 
 		// Register all of this plugin's shortcodes

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -673,7 +673,7 @@ class SyntaxHighlighter {
 			add_shortcode( $shortcode_tagname, array( $this, 'return_entire_shortcode_callback' ) );
 		}
 
-		$regex = '/' . get_shortcode_regex( array_merge( $this->shortcodes, array_keys( $orig_shortcode_tags ) ) ) . '/';
+		$regex = '/' . get_shortcode_regex() . '/';
 
 		// Parse the shortcodes (only this plugins's are registered)
 		if ( $ignore_html ) {

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -689,8 +689,8 @@ class SyntaxHighlighter {
 		// Register all other shortcodes, ensuring their content remains unchanged using yet another hack.
 		foreach ( $orig_shortcode_tags as $shortcode_tagname => $shortcode ) {
 			add_shortcode( $shortcode_tagname, '__return_empty_string' );
-			add_filter( 'pre_do_shortcode_tag', array( $this, 'pre_do_shortcode_shortcode_hack_skip_others' ), 10, 4 );
 		}
+		add_filter( 'pre_do_shortcode_tag', array( $this, 'pre_do_shortcode_shortcode_hack_skip_others' ), 10, 4 );
 
 		$regex = '/' . get_shortcode_regex() . '/';
 

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1377,7 +1377,7 @@ class SyntaxHighlighter {
 		$code = ( false === strpos( $code, '<' ) && false === strpos( $code, '>' ) && 2 == $this->get_code_format( $post ) ) ? strip_tags( $code ) : htmlspecialchars( $code );
 
 		// Escape shortcodes
-		$code = preg_replace( '/\[/', '&#91;', $code );
+		$code = preg_replace( '/\[/', '&#x5B;', $code );
 
 		$params[] = 'notranslate'; // For Google, see http://otto42.com/9k
 


### PR DESCRIPTION
Fixes #32,  #26 and #71 - Fix nested shortcode bugs

This PR addresses issue #32 (Nested shortcode problem). It ensures the plugin doesn't run its own shortcodes multiple times and corrects the original escape method used to replace open square bracket symbols. The original method replaced the `[` symbols with `&#91;` to prevent nested shortcodes from running. However, as indicated in the docs (https://developer.wordpress.org/reference/functions/do_shortcode/ and https://developer.wordpress.org/reference/functions/unescape_invalid_shortcodes/), `&#91;` is converted back to `[`. To address this, we've changed `&#91;` to `&#x5B;`. This modification resolves the issue while preserving the initial escape intention.

Additionally, this PR solves issues #26 and #71 by relying on WordPress's shortcode parsing. This lets SyntaxHighlighter's shortcode strings (e.g., [c]) be used within other shortcodes without interference from SyntaxHighlighter. This solution aims to prevent compatibility issues as illustrated in #71.

The solution proposed for #26 and #71 is somewhat intrusive, as it rewrites the shortcode strings for all shortcodes other than SyntaxHighlighter's. I've considered various scenarios and believe the logic to be robust against edge cases: 

- **Nested shortcodes** - WordPress is tasked with handling these, ensuring only the outermost shortcodes are parsed.
- **Attribute Formatting** - Attributes might use either single or double quotes. This PR transitions all to double quotes and employs esc_attr for attribute escaping. Additional testing is encouraged, though this method has been robust in my tests.
- **Self-closing Shortcodes** - The PR converts self-closing shortcodes to standard format (e.g., [shortcode] and [shortcode/] become [shortcode][/shortcode]). WordPress treats both in the same manner.

If the fix to #26 and #71 is deemed to be too intrusive, the first two commits fix #32. Nonetheless, I believe the code here is as safe as the rest of SyntaxHighlighter's code when it comes to compatibility.

## Changes proposed in this Pull Request ##

- Prevent SyntaxHighlighter's shortcodes from running multiple times.
- Fix the nested shortcodes escape method within shortcode_callback.
- Allow other shortcodes to contain SyntaxHighlighter's shortcode strings (e.g., `[c]`).


## Testing instructions ##

To test instructions from #260 can be used.

As an aditional test this shortcode structure can be used:

```
function attribute_testing_shortcode( $atts ) {
    $a = shortcode_atts( array(
        'att1' => '',
        'att2' => '',
        'att3' => '',
    ), $atts );

    $response = '';
    if ( ! empty( $a['att1'] ) ) {
        $response .= ' ' . $a['att1'];
    }
    if ( ! empty( $a['att2'] ) ) {
        $response .= ' ' . $a['att2'];
    }
    if ( ! empty( $a['att3'] ) ) {
        $response .= ' ' . $a['att3'];
    }
    return $response;
}
add_shortcode( 'attribute_testing', 'attribute_testing_shortcode' );
```

```
<!-- wp:shortcode -->
[c] int i = data[c]; [/c]
<!-- /wp:shortcode -->

<!-- wp:shortcode -->
[attribute_testing att1=one att2='two"' att3="three'''" ]
<!-- /wp:shortcode -->

<!-- wp:shortcode -->
[yell] Yelling data[c] [/yell]
<!-- /wp:shortcode -->

<!-- wp:shortcode -->
[yell] [[c]] [/yell]
<!-- /wp:shortcode -->
```