### PR TITLE
SyntaxHighlighter: Ensure box sizing accounts for added padding.

### DIFF
--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -59,6 +59,7 @@
 }
 
 .syntaxhighlighter {
+  box-sizing: border-box;
   width: 100% !important;
   margin: 1em 0 1em 0 !important;
   position: relative !important;
@@ -80,7 +81,7 @@
   font-style: italic !important;
 }
 .syntaxhighlighter .line {
-  white-space: pre !important;
+  white-space: pre-wrap;
 }
 .syntaxhighlighter table {
   table-layout: auto !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -63,10 +63,13 @@
   width: 100% !important;
   margin: 1em 0 1em 0 !important;
   position: relative !important;
-  overflow: auto !important;
+  overflow-x: scroll !important;
   overflow-y: hidden !important;
   font-size: 1em !important;
   padding: 0.5em 1em !important;
+}
+.entry-content:has(.syntaxhighlighter) {
+  max-width: 100% !important;
 }
 .syntaxhighlighter code {
   display: inline !important;
@@ -81,7 +84,7 @@
   font-style: italic !important;
 }
 .syntaxhighlighter .line {
-  white-space: pre-wrap;
+  white-space: pre !important;
 }
 .syntaxhighlighter table {
   table-layout: auto !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -63,7 +63,7 @@
   width: 100% !important;
   margin: 1em 0 1em 0 !important;
   position: relative !important;
-  overflow-x: auto !important;
+  overflow: auto !important;
   overflow-y: hidden !important;
   font-size: 1em !important;
   padding: 0.5em 1em !important;

--- a/syntaxhighlighter3/styles/shCore.css
+++ b/syntaxhighlighter3/styles/shCore.css
@@ -63,13 +63,10 @@
   width: 100% !important;
   margin: 1em 0 1em 0 !important;
   position: relative !important;
-  overflow-x: scroll !important;
+  overflow-x: auto !important;
   overflow-y: hidden !important;
   font-size: 1em !important;
   padding: 0.5em 1em !important;
-}
-.entry-content:has(.syntaxhighlighter) {
-  max-width: 100% !important;
 }
 .syntaxhighlighter code {
   display: inline !important;


### PR DESCRIPTION
Related to https://github.com/Automattic/themes/issues/8247

### Changes proposed in this Pull Request

* Ensure we're using `border-box` box-sizing for the SyntaxHighlighter so it doesn't overflow the content container due to added padding.

### Testing instructions

* Visual inspection should suffice.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
