### PR TITLE
Fix escaping when language is unknown

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -557,8 +557,14 @@ class SyntaxHighlighter {
 
 		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
 
-		// Undo escaping done by WordPress
-		$code = htmlspecialchars_decode( $code );
+		$language = null;
+		if ( isset( $attributes['language'] ) ) {
+			$language = $attributes['language'];
+		}
+		if ( isset( $this->brushes[ $language ] ) )  {
+			// Undo escaping done by WordPress
+			$code = htmlspecialchars_decode( $code );
+		}
 		$code = preg_replace( '/^(\s*https?:)&#0?47;&#0?47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
 
 		$code = $this->shortcode_callback( $attributes, $code, 'code' );


### PR DESCRIPTION
Fix escaping when language is unknown. See https://github.com/Automattic/syntaxhighlighter-private/pull/3 for more details