### PR TITLE
PHP 8.5 Compat: use colon after case/default in switch statement

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -1112,10 +1112,10 @@ class SyntaxHighlighter {
 			case 'true':
 				echo 'true';
 				break;
-			case 'false';
+			case 'false':
 				echo 'false';
 				break;
-			default;
+			default:
 				echo (int) $this->settings['padlinenumbers'];
 		}
 		echo ";\n";


### PR DESCRIPTION
## Summary
- Replace `;` with `:` after `case 'false'` and `default` in the `padlinenumbers` switch block in `syntaxhighlighter.php`. PHP 8.5 emits a deprecation warning for case/default statements terminated with a semicolon.

Fixes #290

## Backward compatibility
The semicolon form was always parsed by PHP as `case X:` followed by an empty statement, so runtime behavior is identical across PHP 5.x → 8.5+. This is a pure syntax correction with no functional change.

## Test plan
- [x] `php -l syntaxhighlighter.php` — no syntax errors
- [x] Verified no other `case X;` / `default;` patterns exist in the codebase
- [x] Confirm no PHP 8.5 deprecation warning is emitted when rendering a post with the `padlinenumbers` setting in each of its three branches (`true`, `false`, integer)