### PR TITLE
Remove redundant type='text/javascript' from inline script tags

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -618,7 +618,7 @@ class SyntaxHighlighter {
 		foreach ( $this->shortcodes as $shortcode )
 			$shortcodes[] = preg_quote( $shortcode );
 
-		echo "<script type='text/javascript'>\n";
+		echo "<script>\n";
 		echo "	var syntaxHLcodes = '" . implode( '|', $shortcodes ) . "';\n";
 		echo "</script>\n";
 	}
@@ -990,7 +990,7 @@ class SyntaxHighlighter {
 		wp_print_scripts( $scripts );
 
 		// Stylesheets can't be in the footer, so inject them via Javascript
-		echo "<script type='text/javascript'>\n";
+		echo "<script>\n";
 		echo "	(function(){\n";
 		echo "		var corecss = document.createElement('link');\n";
 		echo "		var themecss = document.createElement('link');\n";
@@ -1421,7 +1421,7 @@ class SyntaxHighlighter {
 	// Settings page
 	function settings_page() { ?>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 	jQuery(document).ready(function( $ ) {
 		// Confirm pressing of the "Reset to Defaults" button


### PR DESCRIPTION
## Summary
- Drop `type='text/javascript'` from the three inline `<script>` tags emitted by `syntaxhighlighter.php` (lines 621, 993, 1424). The attribute is the default in HTML5 and is flagged by HTML validators.

Fixes #288

## Backward compatibility
- HTML5 / living-standard browsers: identical behavior — `text/javascript` is the default `type`.
- Legacy XHTML / HTML 4.01 documents: technically required the attribute, but modern WordPress emits an HTML5 doctype and core itself prints inline scripts without `type` (see `wp_print_inline_script_tag()`). No realistic regression for users running a supported WP version.

## Test plan
- [x] `php -l syntaxhighlighter.php` — no syntax errors
- [x] `grep "<script"` — all three remaining tags now lack the `type` attribute
- [x] Render a post containing `[sourcecode]` and confirm the inline `<script>` tag in the page source has no `type` attribute and the highlighter still initializes
- [ ] Open the plugin Settings page and confirm the "Reset to Defaults" confirm dialog still works (the script at line 1424 still binds via jQuery)
- [ ] Run the page through the W3C Nu HTML Checker and confirm the previous warning about `type='text/javascript'` is gone